### PR TITLE
Cheat shadowstar now uses 75% black instead of 100%

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -52,6 +52,7 @@ Changelog for 1.3.7-dev
 -Fix TheXTech 1.3.6.1 peculiarity where a player could reach an inaccessible location by respawning while another player was scrolling (@ds-sloth)
 -Editor: fix TheXTech 1.3.6 bug where level test might incorrectly start following text input (@ds-sloth)
 -Fix vanilla peculiarity where some held NPCs would appear to move on the player's hands / feet, guarded by compat flag "fix-visual-bugs" [Modern Mode] (@ds-sloth)
+-Change cheat "shadowstar" to use a 75% black tint (instead of 100% as in SMBX 1.3) for visibility against dark level backgrounds (@0lhi, @ds-sloth)
 
 Changelog for 1.3.6.6-dev
 -Fix vanilla bug where vehicle could be vulnerable if player entered it during AltJump (requires frame perfect down press), guarded by compat flag "fix-vehicle-altjump-bug" (@ds-sloth)

--- a/src/graphics/gfx_draw_player.cpp
+++ b/src/graphics/gfx_draw_player.cpp
@@ -205,7 +205,7 @@ void DrawPlayer(Player_t &p, const int Z, XTColor color)
 
     int B = 0;
     // double C = 0;
-    XTColor s = (ShadowMode ? XTColor(0, 0, 0, color.a) : color);
+    XTColor s = (ShadowMode ? XTColor(64, 64, 64, color.a) : color);
     //auto &p = Player[A];
 
     int sX = camX + s_round2int_plr(p.Location.X);

--- a/src/graphics/gfx_update.cpp
+++ b/src/graphics/gfx_update.cpp
@@ -421,7 +421,7 @@ static inline void s_get_NPC_tint(int A, XTColor& cn)
         }
     }
 
-    cn = n.Shadow ? XTColor(0, 0, 0) : XTColor();
+    cn = n.Shadow ? XTColor(64, 64, 64) : XTColor();
 }
 
 // draws a warning icon for offscreen active NPC A on vScreen Z
@@ -1816,7 +1816,7 @@ void UpdateGraphicsDraw(bool skipRepaint)
 
 void UpdateGraphicsScreen(Screen_t& screen)
 {
-    XTColor plr_shade = ShadowMode ? XTColor(0, 0, 0) : XTColor();
+    XTColor plr_shade = ShadowMode ? XTColor(64, 64, 64) : XTColor();
 
     int numScreens = screen.active_end();
 
@@ -2508,7 +2508,7 @@ void UpdateGraphicsScreen(Screen_t& screen)
                 {
                     g_stats.renderedEffects++;
 
-                    XTColor cn = Effect[A].Shadow ? XTColor(0, 0, 0) : XTColor();
+                    XTColor cn = Effect[A].Shadow ? XTColor(64, 64, 64) : XTColor();
                     XRender::renderTextureBasic(sX, sY, w, h,
                                            GFXEffect[Effect[A].Type], 0,
                                            Effect[A].Frame * EffectHeight[Effect[A].Type], cn);
@@ -2851,7 +2851,7 @@ void UpdateGraphicsScreen(Screen_t& screen)
         for(size_t i = 0; i < NPC_Draw_Queue_p.Held_n; i++)
         {
             int A = NPC_Draw_Queue_p.Held[i];
-            XTColor cn = NPC[A].Shadow ? XTColor(0, 0, 0) : XTColor();
+            XTColor cn = NPC[A].Shadow ? XTColor(64, 64, 64) : XTColor();
 
             if(NPC[A].Type == NPCID_ICE_CUBE)
             {
@@ -3045,7 +3045,7 @@ void UpdateGraphicsScreen(Screen_t& screen)
                 {
                     g_stats.renderedEffects++;
 
-                    XTColor cn = e.Shadow ? XTColor(0, 0, 0) : XTColor();
+                    XTColor cn = e.Shadow ? XTColor(64, 64, 64) : XTColor();
                     XRender::renderTextureBasic(sX, sY, w, h,
                         GFXEffectBMP[e.Type], 0, e.Frame * EffectHeight[e.Type], cn);
                 }


### PR DESCRIPTION
Why do this?
* Original behavior was invisible against a black background.

Why not allow the old behavior in compat mode?
* This is a cheat code and normally used for debugging purposes only.
* The render code is extremely hot and it would slow the game down on low-end targets to check a compat flag here.