### PR TITLE
Implemented the in-game assert failure message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1311,7 +1311,12 @@ elseif(PGE_MIN_PORT)
     target_compile_definitions(thextech PRIVATE -DLOW_MEM)
 endif()
 
-if(NINTENDO_DS OR NINTENDO_3DS OR NINTENDO_WII OR NINTENDO_SWITCH OR ANDROID OR EMSCRIPTEN)
+if(VITA OR NINTENDO_3DS OR NINTENDO_WII OR NINTENDO_WIIU OR NUNTENDO_SWITCH)
+    # Run in-game message box to show assert failures on platforms without SDL's message box
+    target_compile_definitions(thextech PRIVATE -DTHEXTECH_ASSERTS_INGAME_MESSAGE)
+endif()
+
+if(VITA OR NINTENDO_DS OR NINTENDO_3DS OR NINTENDO_WII OR NINTENDO_SWITCH OR ANDROID OR EMSCRIPTEN)
     # Disable language tools at non-desktop platforms
     target_compile_definitions(thextech PRIVATE -DTHEXTECH_DISABLE_LANG_TOOLS)
 endif()

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 TheXTech Changelog.
 
 Changelog for 1.3.7-dev
+-Implemented the in-game assert failures will be shown as in-game message box until perform an emergency close on platforms that doesn't have SDL's message box (@Wohlstand)
 
 Changelog for 1.3.7-beta
 -Add ability to trigger event layer smoke in the in-game editor (@ds-sloth)

--- a/lib/CrashHandler/crash_handler.h
+++ b/lib/CrashHandler/crash_handler.h
@@ -27,6 +27,7 @@ public:
     static void crashByUnhandledException();
     static void crashByFlood();
     static void initSigs();
+    static void logAssertInfo(const void *data);
 };
 
 #endif // CRASHHANDLER_H

--- a/src/globals.h
+++ b/src/globals.h
@@ -1323,6 +1323,8 @@ enum MessageType
     MESSAGE_TYPE_SYS_WARNING,
     // Has title, red colour
     MESSAGE_TYPE_SYS_ERROR,
+    // Has title, red colour, game will quit after closing this
+    MESSAGE_TYPE_SYS_FATAL_ASSERT,
 };
 extern MessageType g_MessageType;
 

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -142,6 +142,11 @@ void DrawMessage(const std::string& SuperText);
  */
 void DrawMessage(const UTF8CharMap_t& SuperTextMap);
 
+/*!
+ * \brief This is a very special function that runs only last state of the texture
+ */
+void UpdateGraphicsFatalAssert();
+
 // Public Sub SetRes()
 // void SetRes(); //deprecated
 // Public Function CheckKey(newStrizzle As String) As String

--- a/src/graphics/gfx_message.cpp
+++ b/src/graphics/gfx_message.cpp
@@ -4,6 +4,9 @@
 #include "../graphics.h"
 #include "core/render.h"
 #include "../gfx.h"
+#include "../draw_planes.h"
+#include "../frame_timer.h"
+#include "../config.h"
 
 #include "fontman/font_manager_private.h"
 #include "fontman/font_manager.h"
@@ -107,6 +110,7 @@ void DrawMessage(const UTF8CharMap_t &SuperTextMap)
         titleColour = {0xf5, 0xff, 0x1a};
         break;
     case MESSAGE_TYPE_SYS_ERROR:
+    case MESSAGE_TYPE_SYS_FATAL_ASSERT:
         messageColour = {0x61, 0x00, 0x0F};
         titleColour = {0xf5, 0xff, 0x1a};
         break;
@@ -246,4 +250,33 @@ void DrawMessage(const UTF8CharMap_t &SuperTextMap)
         BoxY += lineHeight;
         firstLine = false;
     }
+}
+
+void UpdateGraphicsFatalAssert()
+{
+    cycleNextInc();
+
+    static int cycles = 0;
+
+    if(g_config.enable_frameskip && !TakeScreen && frameSkipNeeded())
+        return;
+
+    XRender::setTargetTexture();
+    XRender::resetViewport();
+    XRender::setDrawPlane(PLANE_LVL_META);
+
+    if(PrintFPS > 0 && g_config.show_fps)
+        SuperPrint(std::to_string(PrintFPS), 1, XRender::TargetOverscanX + 8, 8, {0, 255, 0});
+
+    if(MessageTextMap.empty())
+        DrawMessage(MessageText);
+    else
+        DrawMessage(MessageTextMap);
+
+    SuperPrintScreenCenter(std::to_string(cycles++), 1, 8, {0, 0, 255});
+
+    if(cycles > 650)
+        cycles = 0;
+
+    XRender::repaint();
 }

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -1314,7 +1314,10 @@ void InitSound()
     }
 
     if(LoadingInProcess)
+    {
+        LoaderUpdateDebugString("All sounds loaded");
         UpdateLoad();
+    }
 
     Mix_ReserveChannels(g_reservedChannels);
 
@@ -1514,12 +1517,23 @@ bool HasSound(int A)
 
 void PlaySoundMenu(int A, int loops)
 {
-    if(SoundPause[A] == 0) // if the sound wasn't just played
+    if(SoundPause[A] > 0) // if the sound wasn't just played
+        return;
+
+    if(g_totalSounds == 0)
     {
-        std::string alias = fmt::format_ne("sound{0}", A);
-        PlaySfx(alias, loops);
-        s_resetSoundDelay(A);
+        playFallbackSfx(A, loops, 128);
+        return;
     }
+
+    std::string alias = fmt::format_ne("sound{0}", A);
+    PlaySfx(alias, loops);
+    s_resetSoundDelay(A);
+}
+
+void PlayErrorSound(int A, int loops)
+{
+    playFallbackSfx(A, loops, 128);
 }
 
 // stops all sound from being played for 10 cycles

--- a/src/sound.h
+++ b/src/sound.h
@@ -235,6 +235,7 @@ void Sound_ResolveSpatialMod(uint8_t& left, uint8_t& right, int l, int t, int r,
 // Check does sound is defined at sounds.ini
 bool HasSound(int A);
 void PlaySoundMenu(int A, int loops = 0);
+void PlayErrorSound(int A, int loops = 0);
 // Public Sub BlockSound() 'stops all sound from being played for 10 cycles
 // stops all sound from being played for 10 cycles
 void BlockSound();


### PR DESCRIPTION
On platforms that doesn't have SDL's message box implemented, show the in-game assertion error message until close the game. Debugged primarily on Wii U, need to test on Vita, 3DS, Switch, and Wii.

This is required to avoid undescribed dead freezes and crashes without of any explanation left, just because of no message box implementation on these platforms.