### PR TITLE
Add sound thread to do non-blocking SFX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -772,6 +772,7 @@ set(THEXTECH_SRC
     src/globals.cpp
     src/npc.cpp
     src/sound.cpp
+    src/sound_thread.cpp
     src/sound_spatial.cpp
     src/sound/sound_msgsnd.cpp
     src/frame_timer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -775,7 +775,6 @@ set(THEXTECH_SRC
     src/globals.cpp
     src/npc.cpp
     src/sound.cpp
-    src/sound_thread.cpp
     src/sound_spatial.cpp
     src/sound/sound_msgsnd.cpp
     src/frame_timer.cpp
@@ -893,6 +892,10 @@ set(THEXTECH_SRC
     src/fontman/hardcoded_font.cpp
     src/fontman/utf8_helpers.cpp
 )
+
+if(NOT THEXTECH_NO_SDL_BUILD)
+    list(APPEND THEXTECH_SRC src/sound_thread.cpp)
+endif()
 
 if(THEXTECH_ENABLE_TTF_SUPPORT)
     add_definitions(-DTHEXTECH_ENABLE_TTF_SUPPORT)

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ Changelog for 1.3.7.1-dev
 -Fix TheXTech 1.3.7 peculiarity where NPCs that hid themselves on activation would be shown before coming onscreen (@ds-sloth)
 -Fix TheXTech 1.3.7 peculiarity where player preview sprites in the main menu would not use the correct death effects (@ds-sloth)
 -Fix TheXTech 1.3.6.1 bug where a plant on a hidden moving layer would sometimes not appear after showing the layer (@ds-sloth, @Wohlstand)
+-3DS: fix bug where gameplay could slow down when audio performance is reduced (@ds-sloth)
 
 Changelog for 1.3.7
 -Fix vanilla peculiarity where medals were sometimes not collected when killed, guarded by "fix-medal-kill" [Modern Mode] (@ds-sloth, thanks to @Superbloxen for the report)

--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -34,6 +34,7 @@
 #include "main/screen_progress.h"
 
 #include "sound.h"
+#include "sound_thread.h"
 
 #ifdef THEXTECH_ENABLE_AUDIO_FX
 #include "sound/fx/reverb.h"
@@ -363,6 +364,8 @@ void InitMixerX()
         // Set channel finished callback to handle finished custom SFX
         Mix_ChannelFinished(&extSfxStopCallback);
 
+        StartSfxThread();
+
         g_mixerLoaded = true;
     }
 #endif // #ifndef THEXTECH_NO_SDL_BUILD
@@ -390,6 +393,8 @@ void QuitMixerX()
 {
     if(!g_mixerLoaded)
         return;
+
+    EndSfxThread();
 
     UnloadExtSounds();
 
@@ -751,7 +756,7 @@ void PlayMusic(const std::string &Alias, int fadeInMs)
         pLogWarning("Unknown music alias '%s'", Alias.c_str());
 }
 
-void PlaySfx(int Alias, int loops, int volume, uint8_t left, uint8_t right)
+void PlaySfx_Blocking(int Alias, int loops, int volume, uint8_t left, uint8_t right)
 {
     if(!g_mixerLoaded || (int)g_config.audio_sfx_volume == 0)
         return;

--- a/src/sound.h
+++ b/src/sound.h
@@ -184,7 +184,7 @@ void SoundPauseEngine(int paused);
 // Public Sub PlayMusic(Alias As String)
 void PlayMusic(const std::string &Alias, int fadeInMs = 0);
 // Public Sub PlaySfx(Alias As String)
-void PlaySfx(int Alias, int loops = 0, int volume = 128, uint8_t left = 255, uint8_t right = 255);
+void PlaySfx_Blocking(int Alias, int loops, int volume, uint8_t left, uint8_t right);
 // Public Sub StopSfx(Alias As String)
 void StopSfx(int Alias);
 // Public Sub StartMusic(A As Integer) 'play music

--- a/src/sound.h
+++ b/src/sound.h
@@ -184,7 +184,7 @@ void SoundPauseEngine(int paused);
 // Public Sub PlayMusic(Alias As String)
 void PlayMusic(const std::string &Alias, int fadeInMs = 0);
 // Public Sub PlaySfx(Alias As String)
-void PlaySfx_Blocking(int Alias, int loops, int volume, uint8_t left, uint8_t right);
+void PlaySfx_Blocking(int Alias, int loops = 0, int volume = 128, uint8_t left = 255, uint8_t right = 255);
 // Public Sub StopSfx(Alias As String)
 void StopSfx(int Alias);
 // Public Sub StartMusic(A As Integer) 'play music

--- a/src/sound_thread.cpp
+++ b/src/sound_thread.cpp
@@ -1,0 +1,166 @@
+/*
+ * TheXTech - A platform game engine ported from old source code for VB6
+ *
+ * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
+ * Copyright (c) 2020-2025 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef THEXTECH_NO_SDL_BUILD
+
+#include <vector>
+#include <cstdint>
+#include <exception>
+
+#include <SDL2/SDL_thread.h>
+#include <SDL2/SDL_mutex.h>
+
+#include "sound.h"
+#include "sound_thread.h"
+
+struct EnqueuedSfx_t
+{
+    int Alias;
+    uint8_t loops;
+    uint8_t volume;
+    uint8_t left;
+    uint8_t right;
+};
+
+static std::vector<EnqueuedSfx_t> s_sfx_queue;
+
+static SDL_Thread* s_sound_thread = nullptr;
+static SDL_mutex*  s_sound_thread_mutex = nullptr;
+static SDL_cond*   s_sound_thread_cond = nullptr;
+
+static bool        s_sound_thread_quit = false;
+
+static int s_sound_thread_main(void*)
+{
+    static std::vector<EnqueuedSfx_t> s_sfx_queue_pop;
+    s_sfx_queue_pop.clear();
+
+    while(true)
+    {
+        // load state from the main thread
+        SDL_LockMutex(s_sound_thread_mutex);
+
+        if(!s_sound_thread_quit && s_sfx_queue.empty())
+            SDL_CondWait(s_sound_thread_cond, s_sound_thread_mutex);
+
+        bool quit = s_sound_thread_quit;
+        std::swap(s_sfx_queue, s_sfx_queue_pop);
+
+        SDL_UnlockMutex(s_sound_thread_mutex);
+
+        if(quit)
+            break;
+
+        // execute SFX queue
+        for(const EnqueuedSfx_t& sfx : s_sfx_queue_pop)
+            PlaySfx_Blocking(sfx.Alias, sfx.loops, sfx.volume, sfx.left, sfx.right);
+
+        s_sfx_queue_pop.clear();
+    }
+
+    return 0;
+}
+
+void PlaySfx(int Alias, int loops, int volume, uint8_t left, uint8_t right)
+{
+    if(!s_sound_thread)
+    {
+        PlaySfx_Blocking(Alias, loops, volume, left, right);
+        return;
+    }
+
+    SDL_LockMutex(s_sound_thread_mutex);
+
+    try
+    {
+        s_sfx_queue.push_back(EnqueuedSfx_t{Alias, (uint8_t)loops, (uint8_t)volume, left, right});
+    }
+    catch(...)
+    {
+        SDL_UnlockMutex(s_sound_thread_mutex);
+
+        std::exception_ptr e = std::current_exception();
+
+        if(e)
+            std::rethrow_exception(e);
+    }
+
+    SDL_UnlockMutex(s_sound_thread_mutex);
+    SDL_CondSignal(s_sound_thread_cond);
+}
+
+void StartSfxThread()
+{
+    EndSfxThread();
+
+    s_sound_thread_mutex = SDL_CreateMutex();
+    if(!s_sound_thread_mutex)
+        return;
+
+    s_sound_thread_cond = SDL_CreateCond();
+    if(!s_sound_thread_cond)
+        return;
+
+    s_sound_thread = SDL_CreateThread(s_sound_thread_main, "SFX thread", nullptr);
+}
+
+void EndSfxThread()
+{
+    if(s_sound_thread)
+    {
+        SDL_LockMutex(s_sound_thread_mutex);
+        s_sound_thread_quit = true;
+        SDL_UnlockMutex(s_sound_thread_mutex);
+        SDL_CondSignal(s_sound_thread_cond);
+
+        SDL_WaitThread(s_sound_thread, nullptr);
+        s_sound_thread = nullptr;
+        s_sound_thread_quit = false;
+    }
+
+    if(s_sound_thread_cond)
+    {
+        SDL_DestroyCond(s_sound_thread_cond);
+        s_sound_thread_cond = nullptr;
+    }
+
+    if(s_sound_thread_mutex)
+    {
+        SDL_DestroyMutex(s_sound_thread_mutex);
+        s_sound_thread_mutex = nullptr;
+    }
+}
+
+#else // #ifndef THEXTECH_NO_SDL_BUILD
+
+// fallback: just call directly
+
+#include "sound.h"
+
+void PlaySfx(int Alias, int loops, int volume, uint8_t left, uint8_t right)
+{
+    PlaySfx_Blocking(Alias, loops, volume, left, right);
+}
+
+void StartSfxThread() {}
+
+void EndSfxThread() {}
+
+#endif // #ifndef THEXTECH_NO_SDL_BUILD

--- a/src/sound_thread.cpp
+++ b/src/sound_thread.cpp
@@ -18,8 +18,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef THEXTECH_NO_SDL_BUILD
-
 #include <vector>
 #include <cstdint>
 #include <exception>
@@ -147,20 +145,3 @@ void EndSfxThread()
         s_sound_thread_mutex = nullptr;
     }
 }
-
-#else // #ifndef THEXTECH_NO_SDL_BUILD
-
-// fallback: just call directly
-
-#include "sound.h"
-
-void PlaySfx(int Alias, int loops, int volume, uint8_t left, uint8_t right)
-{
-    PlaySfx_Blocking(Alias, loops, volume, left, right);
-}
-
-void StartSfxThread() {}
-
-void EndSfxThread() {}
-
-#endif // #ifndef THEXTECH_NO_SDL_BUILD

--- a/src/sound_thread.h
+++ b/src/sound_thread.h
@@ -1,0 +1,34 @@
+/*
+ * TheXTech - A platform game engine ported from old source code for VB6
+ *
+ * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
+ * Copyright (c) 2020-2025 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#ifndef SOUND_THREAD_H
+#define SOUND_THREAD_H
+
+// enqueues the SFX but does not block
+void PlaySfx(int Alias, int loops = 0, int volume = 128, uint8_t left = 255, uint8_t right = 255);
+
+// starts sound thread
+void StartSfxThread();
+
+// ends sound thread
+void EndSfxThread();
+
+#endif // #ifndef SOUND_THREAD_H

--- a/src/sound_thread.h
+++ b/src/sound_thread.h
@@ -22,13 +22,38 @@
 #ifndef SOUND_THREAD_H
 #define SOUND_THREAD_H
 
-// enqueues the SFX but does not block
+#include <stdint.h>
+
+#ifndef THEXTECH_NO_SDL_BUILD
+
+/**
+ * @brief Enqueues the SFX but does not block
+ * @param Alias The alias of the sound
+ * @param loops Number loops to play (n-1 value. When -1 - loop forever)
+ * @param volume The volume level between 0 and 128
+ * @param left The panning volume of left channel between 0 and 255
+ * @param right The panning volume of right channel between 0 and 255
+ */
 void PlaySfx(int Alias, int loops = 0, int volume = 128, uint8_t left = 255, uint8_t right = 255);
 
-// starts sound thread
+/**
+ * @brief Starts sound thread
+ */
 void StartSfxThread();
 
-// ends sound thread
+/**
+ * @brief ends sound thread
+ */
 void EndSfxThread();
+
+#else
+
+// fallback: just call directly
+#define PlaySfx PlaySfx_Blocking
+
+static inline void StartSfxThread() {}
+static inline void EndSfxThread() {}
+
+#endif
 
 #endif // #ifndef SOUND_THREAD_H


### PR DESCRIPTION
This puts the SFX play calls into a separate thread. The audio might be slightly choppy in these cases, but the gameplay will no longer be slowed down when the audio is delayed.

Uses `SDL_cond`, so we should check that the game still works on all targets before merging this. **Testing should include changing the MixerX settings in Advanced Settings**

- [x] Linux desktop
- [ ] macOS desktop
- [ ] Windows desktop
- [ ] Android
- [x] Emscripten
- [x] 3DS
- [x] Wii
- [ ] Wii U
- [ ] Switch
- [ ] Vita
- [ ] Haiku

Should resolve #830