### PR TITLE
Added option for real full-screen mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1046,6 +1046,10 @@ else()
         src/core/power/power_sdl.cpp
     )
 
+    if(NOT THEXTECH_FORCE_FULLSCREEN AND NOT EMSCRIPTEN)
+        add_definitions(-DRENDER_FULLSCREEN_TYPES_SUPPORTED)
+    endif()
+
     if(NINTENDO_WIIU)
         list(APPEND THEXTECH_SRC
             src/core/wiiu/msgbox_wiiu.cpp

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Changelog for 1.3.7.1-dev
 -3DS: fix bug where gameplay could slow down when audio performance is reduced (@ds-sloth)
 -Implemented support for Power-of-Two only textures on some platforms via SDL Render (@Wohlstand)
 -Adjusted the frame-skip behaviour to address the performance slowdown on some systems (@Wohlstand)
+-Added exclusive full-screen mode support to maintain good performance on weak devices (@Wohlstand)
 
 Changelog for 1.3.7
 -Fix vanilla peculiarity where medals were sometimes not collected when killed, guarded by "fix-medal-kill" [Modern Mode] (@ds-sloth, thanks to @Superbloxen for the report)

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ Changelog for 1.3.7.1-dev
 -Fixed a bug from the TheXTech 1.3.6 where music of a wrong section gets started when player enters level by a warp into section with no music (@Wohlstand)
 -Fix TheXTech 1.3.7 bug where rail platforms could get stuck below the current section (@ds-sloth, thanks to @Liebning for the report)
 -3DS: fix bug where gameplay could slow down when audio performance is reduced (@ds-sloth)
+-Implemented support for Power-of-Two only textures on some platforms via SDL Render (@Wohlstand)
 
 Changelog for 1.3.7
 -Fix vanilla peculiarity where medals were sometimes not collected when killed, guarded by "fix-medal-kill" [Modern Mode] (@ds-sloth, thanks to @Superbloxen for the report)

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Changelog for 1.3.7.1-dev
 -Fix TheXTech 1.3.7 bug where rail platforms could get stuck below the current section (@ds-sloth, thanks to @Liebning for the report)
 -3DS: fix bug where gameplay could slow down when audio performance is reduced (@ds-sloth)
 -Implemented support for Power-of-Two only textures on some platforms via SDL Render (@Wohlstand)
+-Adjusted the frame-skip behaviour to address the performance slowdown on some systems (@Wohlstand)
 
 Changelog for 1.3.7
 -Fix vanilla peculiarity where medals were sometimes not collected when killed, guarded by "fix-medal-kill" [Modern Mode] (@ds-sloth, thanks to @Superbloxen for the report)

--- a/lib/pge_cpu_arch.h
+++ b/lib/pge_cpu_arch.h
@@ -1,0 +1,97 @@
+/*
+ * TheXTech - A platform game engine ported from old source code for VB6
+ *
+ * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
+ * Copyright (c) 2020-2025 Vitaly Novichkov <admin@wohlnet.ru>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#if defined(_X86_) || defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__) || defined(_M_IX86)
+#   define PGE_CPU_x86
+#   define PGE_CPU_x86_32
+#elif defined(__x86_64__) || defined(__amd64__) || defined(_WIN64) || defined(_M_X64) || defined(_M_AMD64)
+#   define PGE_CPU_x86
+#   define PGE_CPU_x86_64
+#elif defined(__arm__) || defined(__TARGET_ARCH_ARM) || defined(__ARM_ARCH)
+#   if defined(__ARM_ARCH_8__) \
+     || defined(__ARM_ARCH_8A) \
+     || defined(__ARM_ARCH_8A__) \
+     || defined(__ARM_ARCH_8R__) \
+     || defined(__ARM_ARCH_8M__) \
+     || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM >= 8) \
+     || (defined(__ARM_ARCH) && __ARM_ARCH >= 8) || defined(_M_ARM64) || defined(_M_ARM64EC)
+#       define PGE_CPU_ARM64
+#       define PGE_CPU_ARMv8
+#   elif defined(__ARM_ARCH_7__) \
+       || defined(__ARM_ARCH_7A__) \
+       || defined(__ARM_ARCH_7R__) \
+       || defined(__ARM_ARCH_7M__) \
+       || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM >= 7) \
+       || (defined(__ARM_ARCH) && __ARM_ARCH >= 7)
+#       define PGE_CPU_ARM32
+#       define PGE_CPU_ARMv7
+#   elif defined(__ARM_ARCH_6__) \
+       || defined(__ARM_ARCH_6J__) \
+       || defined(__ARM_ARCH_6T2__) \
+       || defined(__ARM_ARCH_6Z__) \
+       || defined(__ARM_ARCH_6K__) \
+       || defined(__ARM_ARCH_6ZK__) \
+       || defined(__ARM_ARCH_6M__) \
+       || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM >= 6) \
+       || (defined(__ARM_ARCH) && __ARM_ARCH >= 6)
+#       define PGE_CPU_ARM32
+#       define PGE_CPU_ARMv6
+#   elif defined(__ARM_ARCH_5TEJ__) \
+      || (defined(__TARGET_ARCH_ARM) && __TARGET_ARCH_ARM >= 5)
+#       define PGE_CPU_ARM32
+#       define PGE_CPU_ARMv5
+#   else
+#       define PGE_CPU_ARM32
+#   endif
+#elif defined(__mips__) || defined(__mips) || defined(__MIPS__)
+#       define PGE_CPU_MIPS
+#elif defined(__ppc__) || defined(__ppc) || defined(__powerpc__) \
+   || defined(_ARCH_COM) || defined(_ARCH_PWR) || defined(_ARCH_PPC)  \
+   || defined(_M_MPPC) || defined(_M_PPC)
+#   if defined(__ppc64__) || defined(__powerpc64__) || defined(__64BIT__)
+#       define PGE_CPU_PPC
+#       define PGE_CPU_PPC64
+#   else
+#       define PGE_CPU_PPC
+#       define PGE_CPU_PPC32
+#   endif
+#elif defined(__riscv) // FIXME: Adjust if any extra macros needed
+#   if defined(__riscv64)
+#       define PGE_CPU_RISCV
+#       define PGE_CPU_RISCV64
+#   elif defined(__riscv32)
+#       define PGE_CPU_RISCV
+#       define PGE_CPU_RISCV32
+#   endif
+#elif defined(__loongarch64)
+#       define PGE_CPU_LOONGARCH
+#       define PGE_CPU_LOONGARCH64
+#elif defined(__loongarch)
+#       define PGE_CPU_LOONGARCH
+#       define PGE_CPU_LOONGARCH32
+#else
+#       define PGE_CPU_UNKNOWN
+#       warning CPU is unknown! Please add missing architecture!
+#endif

--- a/pge_version.h
+++ b/pge_version.h
@@ -194,6 +194,16 @@
 #   else
 #       define FILE_CPU "PowerPC (32-bit)"
 #   endif
+#elif defined(__riscv) // FIXME: Adjust if any extra macros needed
+#   if defined(__riscv64)
+#       define FILE_CPU "RISC-V (64-bit)"
+#   elif defined(__riscv32)
+#       define FILE_CPU "RISC-V (32-bit)"
+#   endif
+#elif defined(__loongarch64)
+#       define FILE_CPU "LoongArch (64-bit)"
+#elif defined(__loongarch)
+#       define FILE_CPU "LoongArch (32-bit)"
 #else
 #   define FILE_CPU "unknown"
 #endif

--- a/resources/languages/thextech_en.json
+++ b/resources/languages/thextech_en.json
@@ -650,6 +650,14 @@
                     "fhd": "1920x1080 (FHD)",
                     "qhd": "2560x1440 (QHD)",
                     "qsmbx": "1600x1200 (QSMBX)"
+                },
+                "fullscreen-type": {
+                    "_name": "Fullscreen type",
+                    "auto": "Auto",
+                    "desktop": "Desktop",
+                    "desktop-tip": "Keep the current screen resolution",
+                    "real": "Exclusive",
+                    "real-tip": "Set physical screen resolution"
                 }
             },
             "audio": {

--- a/src/config.h
+++ b/src/config.h
@@ -565,6 +565,26 @@ public:
     };
 #endif
 
+#ifdef RENDER_FULLSCREEN_TYPES_SUPPORTED
+    enum FullScreenType
+    {
+        FULLSCREEN_TYPE_AUTO = 0,
+        FULLSCREEN_TYPE_DESKTOP = 1,
+        FULLSCREEN_TYPE_REAL = 2
+    };
+    setup_enum_t fullscreen_type{this,
+        {
+            {FULLSCREEN_TYPE_AUTO, "auto", "Auto", nullptr},
+            {FULLSCREEN_TYPE_DESKTOP, "desktop", "Desktop", "Keep the current screen resolution"},
+            {FULLSCREEN_TYPE_REAL, "real", "Exclusive", "Set physical screen resolution"},
+        },
+        defaults(FULLSCREEN_TYPE_AUTO), {},
+        Scope::Config,
+        "fullscreen-type", "Fullscreen type", nullptr,
+        config_fullscreen_type_set
+    };
+#endif // RENDER_FULLSCREEN_TYPES_SUPPORTED
+
 #ifndef THEXTECH_NO_SDL_BUILD
     /* ---- Advanced - Audio ----*/
     subsection advanced_audio{this, "advanced-audio", "Audio"};

--- a/src/config/config_hooks.cpp
+++ b/src/config/config_hooks.cpp
@@ -23,6 +23,9 @@
 
 #include "core/msgbox.h"
 #include "core/events.h"
+#ifdef RENDER_FULLSCREEN_TYPES_SUPPORTED
+#   include "core/window.h"
+#endif
 
 #include "config.h"
 #include "config/config_hooks.h"
@@ -60,6 +63,12 @@ void config_res_set()
     if(GameIsActive && (GameMenu || GamePaused == PauseCode::Options || g_config.internal_res.m_set == ConfigSetLevel::cheat))
         UpdateWindowRes();
     UpdateInternalRes();
+
+#ifdef RENDER_FULLSCREEN_TYPES_SUPPORTED
+    // Sync the real resolution after applying an update
+    if(!XWindow::is_nullptr())
+        XWindow::syncFullScreenRes();
+#endif // RENDER_FULLSCREEN_TYPES_SUPPORTED
 }
 
 void config_rendermode_set()
@@ -90,6 +99,16 @@ void config_fullscreen_set()
 
     XEvents::doEvents();
 }
+
+#ifdef RENDER_FULLSCREEN_TYPES_SUPPORTED
+void config_fullscreen_type_set()
+{
+    if(!GameIsActive)
+        return;
+
+    XWindow::setFullScreenType(g_config.fullscreen_type);
+}
+#endif // RENDER_FULLSCREEN_TYPES_SUPPORTED
 
 void config_mountdrums_set()
 {

--- a/src/config/config_hooks.h
+++ b/src/config/config_hooks.h
@@ -27,6 +27,9 @@ void config_asset_pack_set();
 void config_language_set();
 void config_rendermode_set();
 void config_fullscreen_set();
+#ifdef RENDER_FULLSCREEN_TYPES_SUPPORTED
+void config_fullscreen_type_set();
+#endif
 void config_mountdrums_set();
 void config_screenmode_set();
 void config_audiofx_set();

--- a/src/core/16m/render_16m.cpp
+++ b/src/core/16m/render_16m.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * TheXTech - A platform game engine ported from old source code for VB6
  *
  * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
@@ -57,6 +57,8 @@
 
 namespace XRender
 {
+
+static bool g_is_working = false;
 
 bool g_in_frame = false;
 uint64_t s_last_frame_start = 0;
@@ -484,6 +486,16 @@ static inline bool GL_DrawImage_Custom_Basic(int name, int flags,
     return true;
 }
 
+bool isWorking()
+{
+    return g_is_working;
+}
+
+bool hasFrameBuffer()
+{
+    return true;
+}
+
 bool init()
 {
     lcdMainOnBottom();
@@ -527,6 +539,8 @@ bool init()
     glFogShift(0);
 #endif
 
+    g_is_working = true;
+
     updateViewport();
 
     return true;
@@ -534,6 +548,7 @@ bool init()
 
 void quit()
 {
+    g_is_working = false;
 }
 
 bool ready_for_frame()

--- a/src/core/3ds/render_3ds.cpp
+++ b/src/core/3ds/render_3ds.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * TheXTech - A platform game engine ported from old source code for VB6
  *
  * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
@@ -512,6 +512,16 @@ static inline void s_mergeBlend()
 static inline void s_fadeBlend()
 {
     C3D_AlphaBlend(GPU_BLEND_ADD, GPU_BLEND_ADD, GPU_ZERO, GPU_SRC_ALPHA, GPU_ZERO, GPU_SRC_ALPHA);
+}
+
+bool isWorking()
+{
+    return s_render_inited;
+}
+
+bool hasFrameBuffer()
+{
+    return true;
 }
 
 bool init()

--- a/src/core/base/render_base.h
+++ b/src/core/base/render_base.h
@@ -78,6 +78,12 @@ public:
      */
     virtual bool isWorking() = 0;
 
+    /*!
+     * \brief Tells is frame buffer is currently available or not
+     * \return true if framebuffer is available
+     */
+    virtual bool hasFrameBuffer() = 0;
+
     virtual bool initRender(SDL_Window *window) = 0;
 
     /*!

--- a/src/core/base/window_base.h
+++ b/src/core/base/window_base.h
@@ -91,6 +91,34 @@ public:
      */
     virtual int setFullScreen(bool fs) = 0;
 
+    enum FullScreenType
+    {
+        FULLSCREEN_TYPE_AUTO = 0,
+        FULLSCREEN_TYPE_DESKTOP = 1,
+        FULLSCREEN_TYPE_REAL = 2
+    };
+
+#ifdef RENDER_FULLSCREEN_TYPES_SUPPORTED
+    /*!
+     * \brief Sets the type of fullscreen (desktop or real)
+     * \param type Fullscreen type: 0 auto, 1 desktop, 2 real
+     * \return 1 when full-screen mode toggled, 0 when windowed mode toggled, -1 on any errors
+     */
+    virtual int setFullScreenType(int type) = 0;
+
+    /*!
+     * \brief Get a type of full-screen (desktop or real)
+     * \return type of fullscreen
+     */
+    virtual int getFullScreenType() = 0;
+
+    /*!
+     * \brief Only real full-screen mode: syncs the real resolution with the canvas
+     * \return 0 on success, -1 on any errors
+     */
+    virtual int syncFullScreenRes() = 0;
+#endif // RENDER_FULLSCREEN_TYPES_SUPPORTED
+
     /*!
      * \brief Restore the size and position of a minimized or maximized window.
      */

--- a/src/core/null/render_null.cpp
+++ b/src/core/null/render_null.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * TheXTech - A platform game engine ported from old source code for VB6
  *
  * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
@@ -44,6 +44,16 @@ namespace XRender
 
 int TargetW = 800;
 int TargetH = 600;
+
+bool isWorking()
+{
+    return true;
+}
+
+bool hasFrameBuffer()
+{
+    return false;
+}
 
 bool init()
 {

--- a/src/core/opengl/render_gl.h
+++ b/src/core/opengl/render_gl.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * TheXTech - A platform game engine ported from old source code for VB6
  *
  * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
@@ -575,6 +575,8 @@ public:
     unsigned int SDL_InitFlags() override;
 
     bool isWorking() override;
+
+    bool hasFrameBuffer() override;
 
     bool initRender(SDL_Window *window) override;
 

--- a/src/core/opengl/render_gl_frontend.cpp
+++ b/src/core/opengl/render_gl_frontend.cpp
@@ -91,6 +91,11 @@ bool RenderGL::isWorking()
     return m_gContext;
 }
 
+bool RenderGL::hasFrameBuffer()
+{
+    return m_has_fbo;
+}
+
 RenderGL::VertexList& RenderGL::getOrderedDrawVertexList(RenderGL::DrawContext_t context, int depth)
 {
     // combine draw calls issued in sequence (except bitmask calls)

--- a/src/core/render.h
+++ b/src/core/render.h
@@ -114,6 +114,17 @@ E_INLINE bool isWorking() TAIL
 #endif
 
 /*!
+ * \brief Tells is frame buffer is currently available or not
+ * \return true if framebuffer is available
+ */
+E_INLINE  bool hasFrameBuffer() TAIL
+#ifndef RENDER_CUSTOM
+{
+    return g_render->hasFrameBuffer();
+}
+#endif
+
+/*!
  * \brief Call the repaint
  */
 E_INLINE void repaint() TAIL

--- a/src/core/sdl/render_sdl.cpp
+++ b/src/core/sdl/render_sdl.cpp
@@ -52,7 +52,33 @@
 #define SDL_RenderCopyExF SDL_RenderCopyEx
 #endif
 
+static inline uint32_t pow2roundup(uint32_t x)
+{
+    if(x == 0)
+        return 0;
 
+    --x;
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+    return x + 1;
+}
+
+static inline int32_t pow2roundup(int32_t x)
+{
+    if(x < 0)
+        return 0;
+
+    --x;
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+    return x + 1;
+}
 
 RenderSDL::RenderSDL() :
     AbstractRender_t()
@@ -76,7 +102,7 @@ bool RenderSDL::isWorking()
 
 bool RenderSDL::initRender(SDL_Window *window)
 {
-    pLogDebug("Init renderer settings...");
+    pLogDebug("Render SDL: Init...");
 
     if(!AbstractRender_t::init())
         return false;
@@ -84,6 +110,18 @@ bool RenderSDL::initRender(SDL_Window *window)
     m_window = window;
 
     Uint32 renderFlags = 0;
+
+    int numRenders = SDL_GetNumRenderDrivers();
+    SDL_RendererInfo info;
+    for(int i = 0; i < numRenders; ++i)
+    {
+        SDL_GetRenderDriverInfo(i, &info);
+        pLogDebug("Render SDL: Render device: %s, flags: %u, max-w: %u, max-h: %u",
+                  info.name,
+                  info.flags,
+                  info.max_texture_width,
+                  info.max_texture_height);
+    }
 
     switch(g_config.render_mode)
     {
@@ -93,7 +131,7 @@ bool RenderSDL::initRender(SDL_Window *window)
         {
             renderFlags = SDL_RENDERER_ACCELERATED|SDL_RENDERER_PRESENTVSYNC;
             g_config.render_mode.obtained = Config_t::RENDER_ACCELERATED_SDL;
-            pLogDebug("Using accelerated rendering with a vertical synchronization");
+            pLogDebug("Render SDL: Using accelerated rendering with a vertical synchronization");
             m_gRenderer = SDL_CreateRenderer(window, -1, renderFlags | SDL_RENDERER_TARGETTEXTURE); // Try to make renderer
             if(m_gRenderer)
                 break; // All okay
@@ -104,7 +142,7 @@ bool RenderSDL::initRender(SDL_Window *window)
 
         renderFlags = SDL_RENDERER_ACCELERATED;
         g_config.render_mode.obtained = Config_t::RENDER_ACCELERATED_SDL;
-        pLogDebug("Using accelerated rendering");
+        pLogDebug("Render SDL: Using accelerated rendering");
         m_gRenderer = SDL_CreateRenderer(window, -1, renderFlags | SDL_RENDERER_TARGETTEXTURE); // Try to make renderer
         if(m_gRenderer)
             break; // All okay
@@ -114,12 +152,12 @@ bool RenderSDL::initRender(SDL_Window *window)
     case Config_t::RENDER_SOFTWARE:
         renderFlags = SDL_RENDERER_SOFTWARE;
         g_config.render_mode.obtained = Config_t::RENDER_SOFTWARE;
-        pLogDebug("Using software rendering");
+        pLogDebug("Render SDL: Using software rendering");
         m_gRenderer = SDL_CreateRenderer(window, -1, renderFlags | SDL_RENDERER_TARGETTEXTURE); // Try to make renderer
         if(m_gRenderer)
             break; // All okay
 
-        pLogCritical("Unable to create renderer!");
+        pLogCritical("Render SDL: Unable to create renderer!");
         return false;
     }
 
@@ -130,11 +168,26 @@ bool RenderSDL::initRender(SDL_Window *window)
     m_maxTextureWidth = ri.max_texture_width;
     m_maxTextureHeight = ri.max_texture_height;
 
-    m_tBuffer = SDL_CreateTexture(m_gRenderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, ScaleWidth, ScaleHeight);
+    m_tBuffer = SDL_CreateTexture(m_gRenderer,
+                                  SDL_PIXELFORMAT_ARGB8888,
+                                  SDL_TEXTUREACCESS_TARGET,
+                                  ScaleWidth, ScaleHeight);
+
     if(!m_tBuffer)
     {
-        pLogWarning("Unable to create texture render buffer: %s", SDL_GetError());
-        pLogDebug("Continue without of render to texture. The ability to resize the window will be disabled.");
+        pLogWarning("Render SDL: Failed to create the normal texture render buffer: %s, trying to create a power-2 texture...", SDL_GetError());
+        m_pow2 = true;
+        m_tBuffer = SDL_CreateTexture(m_gRenderer,
+                                      SDL_PIXELFORMAT_ARGB8888,
+                                      SDL_TEXTUREACCESS_TARGET,
+                                      pow2roundup(ScaleWidth), pow2roundup(ScaleHeight));
+    }
+
+    if(!m_tBuffer)
+    {
+        m_pow2 = false;
+        pLogWarning("Render SDL: Unable to create texture render buffer: %s", SDL_GetError());
+        pLogDebug("Render SDL: Continue without of render to texture. The ability to resize the window will be disabled.");
         SDL_SetWindowResizable(window, SDL_FALSE);
         m_tBufferDisabled = true;
     }
@@ -309,10 +362,23 @@ void RenderSDL::updateViewport()
         else
             SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
 
-        SDL_DestroyTexture(m_tBuffer);
+        bool powUpdateNeeded = !m_pow2;
 
-        m_tBuffer = SDL_CreateTexture(m_gRenderer, SDL_PIXELFORMAT_RGBA8888, SDL_TEXTUREACCESS_TARGET, XRender::TargetW, XRender::TargetH);
-        SDL_SetRenderTarget(m_gRenderer, m_tBuffer);
+        if(m_pow2)
+        {
+            powUpdateNeeded |= pow2roundup(XRender::TargetW) != ScaleWidth;
+            powUpdateNeeded |= pow2roundup(XRender::TargetH) != ScaleHeight;
+        }
+
+        if(!m_tBufferDisabled && powUpdateNeeded)
+        {
+            SDL_DestroyTexture(m_tBuffer);
+
+            m_tBuffer = SDL_CreateTexture(m_gRenderer, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET,
+                                          m_pow2 ? pow2roundup(XRender::TargetW) : XRender::TargetW,
+                                          m_pow2 ? pow2roundup(XRender::TargetH) : XRender::TargetH);
+            SDL_SetRenderTarget(m_gRenderer, m_tBuffer);
+        }
 
         // reset scaling setting for images loaded later
         SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "nearest");
@@ -464,8 +530,34 @@ void RenderSDL::loadTextureInternal(StdPicture &target, uint32_t width, uint32_t
                                        FI_RGBA_GREEN_MASK,
                                        FI_RGBA_BLUE_MASK,
                                        FI_RGBA_ALPHA_MASK);
+
     if(surface)
+    {
+textureTryAgain:
+        if(m_pow2)
+        {
+            uint32_t newW = pow2roundup(width);
+            uint32_t newH = pow2roundup(height);
+            pLogDebug("Render SDL: Converting surface into Power-2...");
+            SDL_Surface *newSurface = SDL_CreateRGBSurfaceWithFormat(0, newW, newH, 32, SDL_PIXELFORMAT_ARGB8888);
+            if(newSurface)
+            {
+                SDL_Rect rect = {0, 0, (int)width, (int)height};
+                SDL_LowerBlit(surface, &rect, newSurface, &rect);
+                SDL_FreeSurface(surface);
+                surface = newSurface;
+            }
+        }
+
         texture = SDL_CreateTextureFromSurface(m_gRenderer, surface);
+
+        if(!m_pow2 && !texture) // Try to re-make texture again
+        {
+            pLogWarning("Render SDL: Failed to load texture (%s), trying to turn on the Power-2 mode...", SDL_GetError());
+            m_pow2 = true;
+            goto textureTryAgain;
+        }
+    }
 
     SDL_FreeSurface(surface);
 
@@ -686,7 +778,7 @@ void RenderSDL::execute(const RenderOp& op)
             const SDL_RendererFlip flip = (SDL_RendererFlip)(op.traits & 3);
 
             double angle = (op.traits & RenderOp::Traits::rotation)
-                ? double(op.angle) * (360. / 65536.)
+                ? double(op.angle) * (360.0 / 65536.0)
                 : 0.;
 
             SDL_RenderCopyEx(m_gRenderer, tx.d.texture, sourceRectPtr, &destRect,
@@ -893,7 +985,7 @@ void RenderSDL::renderTextureScale(double xDst, double yDst, double wDst, double
     RenderOp& op = m_render_queue.push(m_recent_draw_plane);
 
     op.type = RenderOp::Type::texture;
-    op.traits = 0;
+    op.traits = m_pow2 ? RenderOp::Traits::src_rect : 0;
 
     op.texture = &tx;
 
@@ -901,6 +993,14 @@ void RenderSDL::renderTextureScale(double xDst, double yDst, double wDst, double
     op.yDst = Maths::iRound(yDst) + m_viewport_offset_y;
     op.wDst = Maths::iRound(wDst);
     op.hDst = Maths::iRound(hDst);
+
+    if(m_pow2)
+    {
+        op.xSrc = 0;
+        op.ySrc = 0;
+        op.wSrc = tx.d.w_scale * tx.w;
+        op.hSrc = tx.d.h_scale * tx.h;
+    }
 
     op.color = color;
 }
@@ -997,7 +1097,7 @@ void RenderSDL::renderTexture(float xDst, float yDst,
     RenderOp& op = m_render_queue.push(m_recent_draw_plane);
 
     op.type = RenderOp::Type::texture;
-    op.traits = 0;
+    op.traits = m_pow2 ? RenderOp::Traits::src_rect : 0;
 
     op.texture = &tx;
 
@@ -1005,6 +1105,14 @@ void RenderSDL::renderTexture(float xDst, float yDst,
     op.yDst = Maths::iRound(yDst) + m_viewport_offset_y;
     op.wDst = tx.w;
     op.hDst = tx.h;
+
+    if(m_pow2)
+    {
+        op.xSrc = 0;
+        op.ySrc = 0;
+        op.wSrc = tx.d.w_scale * tx.w;
+        op.hSrc = tx.d.h_scale * tx.h;
+    }
 
     op.color = color;
 }

--- a/src/core/sdl/render_sdl.cpp
+++ b/src/core/sdl/render_sdl.cpp
@@ -100,6 +100,11 @@ bool RenderSDL::isWorking()
     return m_gRenderer && (m_tBuffer || m_tBufferDisabled);
 }
 
+bool RenderSDL::hasFrameBuffer()
+{
+    return m_tBuffer && !m_tBufferDisabled;
+}
+
 bool RenderSDL::initRender(SDL_Window *window)
 {
     pLogDebug("Render SDL: Init...");

--- a/src/core/sdl/render_sdl.h
+++ b/src/core/sdl/render_sdl.h
@@ -94,6 +94,8 @@ public:
 
     bool isWorking() override;
 
+    bool hasFrameBuffer() override;
+
     bool initRender(SDL_Window *window) override;
 
     /*!

--- a/src/core/sdl/render_sdl.h
+++ b/src/core/sdl/render_sdl.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * TheXTech - A platform game engine ported from old source code for VB6
  *
  * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
@@ -43,6 +43,8 @@ class RenderSDL final : public AbstractRender_t
     bool          m_tBufferDisabled = false;
     SDL_Texture  *m_recentTarget = nullptr;
     std::set<StdPicture *> m_loadedPictures;
+
+    bool m_pow2 = false;
 
     // queue of render ops
     RenderQueue m_render_queue;

--- a/src/core/sdl/window_sdl.h
+++ b/src/core/sdl/window_sdl.h
@@ -36,6 +36,13 @@ class WindowSDL final : public AbstractWindow_t
 
     bool m_fullscreen = false;
 
+#ifdef RENDER_FULLSCREEN_TYPES_SUPPORTED
+    int m_fullscreen_type = 0;
+    int m_fullscreen_type_real = 0;
+    int m_screen_orig_w = 0;
+    int m_screen_orig_h = 0;
+#endif
+
 public:
     WindowSDL();
     virtual ~WindowSDL();
@@ -103,6 +110,29 @@ public:
      * \return 1 when full-screen mode toggled, 0 when windowed mode toggled, -1 on any errors
      */
     int setFullScreen(bool fs) override;
+
+#ifdef RENDER_FULLSCREEN_TYPES_SUPPORTED
+    static void setHasFrameBuffer(bool has);
+
+    /*!
+     * \brief Sets the type of fullscreen (desktop or real)
+     * \param type Fullscreen type: 0 auto, 1 desktop, 2 real
+     * \return 1 when full-screen mode toggled, 0 when windowed mode toggled, -1 on any errors
+     */
+    int setFullScreenType(int type) override;
+
+    /*!
+     * \brief Get a type of full-screen (desktop or real)
+     * \return type of fullscreen
+     */
+    int getFullScreenType() override;
+
+    /*!
+     * \brief Only real full-screen mode: syncs the real resolution with the canvas
+     * \return 0 on success, -1 on any errors
+     */
+    int syncFullScreenRes() override;
+#endif // RENDER_FULLSCREEN_TYPES_SUPPORTED
 
     /*!
      * \brief Restore the size and position of a minimized or maximized window.

--- a/src/core/wii/render_wii.cpp
+++ b/src/core/wii/render_wii.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * TheXTech - A platform game engine ported from old source code for VB6
  *
  * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
@@ -60,6 +60,7 @@ namespace XRender
 
 bool g_in_frame = false;
 
+static bool g_is_working = false;
 static RenderPlanes_t s_render_planes;
 
 #define DEFAULT_FIFO_SIZE   (256*1024)
@@ -573,6 +574,16 @@ void video_set_rmode()
     WPAD_SetVRes(WPAD_CHAN_ALL, g_rmode_w, g_rmode_h);
 }
 
+bool isWorking()
+{
+    return g_is_working;
+}
+
+bool hasFrameBuffer()
+{
+    return true;
+}
+
 bool init()
 {
     GXColor background = {0, 0, 0, 0xff};
@@ -628,6 +639,8 @@ bool init()
              look = {0.0F, 0.0F, -1.0F};
     guLookAt(view, &cam, &up, &look);
 
+    g_is_working = true;
+
     updateViewport();
 
     return true;
@@ -635,6 +648,7 @@ bool init()
 
 void quit()
 {
+    g_is_working = false;
     VIDEO_SetBlack(TRUE);
 }
 

--- a/src/core/window.h
+++ b/src/core/window.h
@@ -168,6 +168,45 @@ E_INLINE int setFullScreen(bool fs) TAIL
 }
 #endif
 
+
+#ifdef RENDER_FULLSCREEN_TYPES_SUPPORTED
+/*!
+ * \brief Sets the type of fullscreen (desktop or real)
+ * \param type Fullscreen type: 0 auto, 1 desktop, 2 real
+ * \return 1 when full-screen mode toggled, 0 when windowed mode toggled, -1 on any errors
+ */
+E_INLINE int setFullScreenType(int type) TAIL
+#ifndef WINDOW_CUSTOM
+{
+    return g_window->setFullScreenType(type);
+}
+#endif
+
+/*!
+ * \brief Get a type of full-screen (desktop or real)
+ * \return type of fullscreen
+ */
+E_INLINE int getFullScreenType() TAIL
+#ifndef WINDOW_CUSTOM
+{
+    return g_window->getFullScreenType();
+}
+#endif
+
+/*!
+ * \brief Only real full-screen mode: syncs the real resolution with the canvas
+ * \return 0 on success, -1 on any errors
+ */
+E_INLINE int syncFullScreenRes() TAIL
+#ifndef WINDOW_CUSTOM
+{
+    return g_window->syncFullScreenRes();
+}
+#endif
+
+#endif // RENDER_FULLSCREEN_TYPES_SUPPORTED
+
+
 /*!
  * \brief Restore the size and position of a minimized or maximized window.
  */

--- a/src/frame_timer.cpp
+++ b/src/frame_timer.cpp
@@ -557,6 +557,7 @@ static inline void computeFrameTime2Real_2()
 #ifdef USE_NEW_FRAMESKIP
     if(s_doUpdate > 0)
         s_doUpdate -= c_frameRateNano;
+
     s_startProcessing = 0;
     s_stopProcessing = 0;
 #endif
@@ -568,6 +569,7 @@ static inline void computeFrameTime2Real_2()
             s_overTime = 0;
             s_gameTime = s_currentTicks;
         }
+
         s_cycleCount = 0;
         s_fpsTime = SDL_GetTicks() + 1000;
         s_goalTime = s_fpsTime;
@@ -593,6 +595,7 @@ static inline void computeFrameTime2Real_2()
                 pLogWarning("frame_timer: Adjusted sleep time got a too big value: %ld", (long)adjustedSleepTime);
                 adjustedSleepTime = 500000000;
             }
+
             xtech_nanosleep(adjustedSleepTime);
             auto e = getElapsedTime(start);
             nanotime_t overslept = e - adjustedSleepTime;
@@ -678,14 +681,15 @@ void frameRenderEnd()
     if(s_doUpdate <= 0)
     {
         s_stopProcessing = getNanoTime();
-        nanotime_t newTime = g_config.enable_frameskip ? (s_stopProcessing - s_startProcessing) : 0;
+        nanotime_t newTime = g_config.enable_frameskip ? (s_stopProcessing - s_startProcessing): 0;
         // D_pLogDebug("newTime/nano=%lld (%lld)", newTime/c_frameRateNano, newTime / 1000000);
         if(newTime > c_frameRateNano * 25) // Limit 25 frames being skipped maximum
         {
-            D_pLogDebug("Overloading detected: %lld frames to skip (%lld milliseconds delay)", newTime/c_frameRateNano, newTime / 1000000);
+            D_pLogDebug("frame_timer: Overloading detected: %lld frames to skip (%lld milliseconds delay)", newTime / c_frameRateNano, newTime / 1000000);
             newTime = c_frameRateNano * 25;
         }
-        s_doUpdate += newTime;
+
+        s_doUpdate += newTime * 300 / 166;
         s_goalTime = double(SDL_GetTicks() + (newTime / 1000000));
     }
 #endif

--- a/src/frm_main.cpp
+++ b/src/frm_main.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * TheXTech - A platform game engine ported from old source code for VB6
  *
  * Copyright (c) 2009-2011 Andrew Spinks, original VB6 code
@@ -152,7 +152,7 @@ bool FrmMain::initSystem(const CmdLineSetup_t &setup)
     if(!res)
     {
 #ifndef THEXTECH_NO_SDL_CORE
-    CoreSDL::quit();
+        CoreSDL::quit();
 #endif
         return true;
     }
@@ -232,6 +232,20 @@ bool FrmMain::initSystem(const CmdLineSetup_t &setup)
         freeSystem();
         return true;
     }
+
+#ifdef RENDER_FULLSCREEN_ALWAYS // Use a full-screen on Android & PS Vita mode by default
+    XWindow::setFullScreen(true);
+    XWindow::show();
+#else
+#   ifdef RENDER_FULLSCREEN_TYPES_SUPPORTED
+    WindowSDL::setHasFrameBuffer(m_render->hasFrameBuffer());
+    XWindow::setFullScreenType(g_config.fullscreen_type);
+    XWindow::setFullScreen(g_config.fullscreen);
+#   endif
+#   ifdef _WIN32
+    XWindow::show();
+#   endif
+#endif
 
     XEvents::doEvents();
 


### PR DESCRIPTION
This mode supposed to toggle real screen resolution, primarily needed to increase performance on slower devices that can't keep enough performance when higher resolutions are used (especially via Desktop Fullscreen mode).

Closes #842

Note: Right now here is no performance measure implemented yet. Instead, there are compile-time target architecture macros yet that sets real full-screen mode by default when it's one of 32-bit architectures.
