### PR TITLE
Add disable-fullscreen-toggle config option

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -190,8 +190,13 @@ public:
     opt<bool> fullscreen{this, defaults(false), {}, Scope::Config,
         "fullscreen", "Fullscreen", nullptr,
         config_fullscreen_set};
+
+    opt<bool> disable_fullscreen_toggle{this, defaults(false), {}, Scope::Config,
+        "disable-fullscreen-toggle", "Disable fullscreen toggle", nullptr,
+        nullptr};
 #else
     static constexpr bool fullscreen = true;
+    static constexpr bool disable_fullscreen_toggle = true;
 #endif
 
     opt_enum<std::pair<int, int>> internal_res{this,

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -546,6 +546,9 @@ static inline int s_round2int(num_t d)
 void ChangeScreen()
 {
 #ifndef RENDER_FULLSCREEN_ALWAYS
+    if(g_config.disable_fullscreen_toggle)
+        return;
+
     // shouldn't be possible
     if(g_config.fullscreen.m_set > ConfigSetLevel::user_config)
     {


### PR DESCRIPTION
Allows the runtime fullscreen toggle (~~F7 hotkey~~  ALT+ENTER) to be disabled via configuration. I run TheXTech on a personal arcade cabinet where the keys ALT and ENTER are buttons that the controller board sends out. When playing two player mode, those keys get toggled in combination really quickly and cannot be remapped, causing the toggle to be accidentally triggered.

Config key: disable-fullscreen-toggle = true
Section: [video-system]