### PR TITLE
Single-file saves

### DIFF
--- a/lib/sdl_proxy_rwops/include/SDL2/SDL_rwops.h
+++ b/lib/sdl_proxy_rwops/include/SDL2/SDL_rwops.h
@@ -34,6 +34,9 @@ extern "C" {
 #define SDL_RWOPS_UNKNOWN   0U  /**< Unknown stream type */
 #define SDL_RWOPS_STDFILE   2U  /**< Stdio file */
 
+#define SDL_TRUE 1
+#define SDL_FALSE 0
+
 #define RW_SEEK_CUR SEEK_CUR
 #define RW_SEEK_SET SEEK_SET
 #define RW_SEEK_END SEEK_END
@@ -93,6 +96,7 @@ typedef struct SDL_RWops
 SDL_RWops* SDL_AllocRW();
 void SDL_FreeRW(SDL_RWops * area);
 SDL_RWops* SDL_RWFromFile(const char* pathname, const char* mode);
+SDL_RWops* SDL_RWFromFP(FILE* f, int autoclose);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/lib/sdl_proxy_rwops/sdl_proxy_rwops_file.c
+++ b/lib/sdl_proxy_rwops/sdl_proxy_rwops_file.c
@@ -87,10 +87,9 @@ static int s_file_close(SDL_RWops* stream)
     return fclose(stream->hidden.unknown.data1);
 }
 
-SDL_RWops* SDL_RWFromFile(const char* pathname, const char* mode)
+SDL_RWops* SDL_RWFromFP(FILE* f, int autoclose)
 {
-    FILE* f = utf8_fopen(pathname, mode);
-    if(!f)
+    if(!f || !autoclose)
         return NULL;
 
     SDL_RWops* ret = SDL_AllocRW();
@@ -111,4 +110,10 @@ SDL_RWops* SDL_RWFromFile(const char* pathname, const char* mode)
     ret->hidden.unknown.data1 = f;
 
     return ret;
+}
+
+SDL_RWops* SDL_RWFromFile(const char* pathname, const char* mode)
+{
+    FILE* f = utf8_fopen(pathname, mode);
+    return SDL_RWFromFP(f, SDL_TRUE);
 }

--- a/src/game_main.cpp
+++ b/src/game_main.cpp
@@ -1162,8 +1162,6 @@ int GameMain(const CmdLineSetup_t &setup)
             // Update graphics before loop begin (to process inital lazy-unpacking of used sprites)
             GraphicsLazyPreLoad();
             resetFrameTimer();
-            // Clear the speed-runner timer
-            speedRun_resetTotal();
 
             lunaLoad();
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -1038,6 +1038,9 @@ struct LevelSaveInfo_t
     // BITMASK
     uint16_t exits_got = 0;
 
+    // Fails count
+    uint16_t fails = 0;
+
     inline bool inited() const
     {
         return max_medals != 255;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,7 @@
 #include "main/game_info.h"
 #include "main/asset_pack.h"
 #include "main/translate.h"
+#include "main/game_save.h"
 #include "core/language.h"
 #include "config.h"
 #include "controls.h"
@@ -839,6 +840,8 @@ int main(int argc, char**argv)
 #endif
 
     Integrator::quitIntegrations();
+
+    CloseSave();
 
 #ifdef ENABLE_XTECH_LUA
     if(!xtech_lua_quit())

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -42,6 +42,23 @@
 #include "menu_main.h"
 #include "saved_layers.h"
 
+
+static SDL_RWops* s_open_gamesave = nullptr;
+static bool s_preloaded = false;
+
+GamesaveAccess::GamesaveAccess()
+{
+    savefile = s_open_gamesave;
+    // TODO: lock here so that we can use threading to help with 3DS hang issues
+}
+
+GamesaveAccess::~GamesaveAccess()
+{
+    if(savefile)
+        Files::flush_file(savefile);
+    // TODO: unlock here
+}
+
 std::string makeGameSavePath(std::string epPath, std::string saveFile)
 {
     std::string gameSaveDir = AppPathManager::gameSaveRootDir() + Files::basename(Files::dirname(epPath));
@@ -274,6 +291,8 @@ void SaveGame()
     if(Cheater || !selSave)
         return;
 
+    CloseSave();
+
     for(A = numPlayers; A >= 1; A--)
         SavedChar[Player[A].Character] = Player[A];
 
@@ -364,7 +383,12 @@ void SaveGame()
 
     ExportLevelSaveInfo(sav);
 
-    FileFormats::WriteExtendedSaveFileF(savePath, sav);
+    FILE* gamesave = Files::utf8_fopen(savePath.c_str(), "w+");
+    PGE_FileFormats_misc::TextFileOutput output(gamesave);
+    FileFormats::WriteExtendedSaveFile(output, sav);
+
+    s_open_gamesave = SDL_RWFromFP(gamesave, SDL_TRUE);
+    Files::flush_file(s_open_gamesave);
 
     if(Files::fileExists(legacyGamesaveLocker))
         Files::deleteFile(legacyGamesaveLocker); // Remove the gamesave locker of legacy file
@@ -378,6 +402,8 @@ void SaveGame()
 #ifdef THEXTECH_ENABLE_SDL_NET
 void PreloadGame()
 {
+    CloseSave();
+
     XMessage::g_session.save_present = 0;
     XMessage::g_session.save_data.clear();
 
@@ -397,18 +423,29 @@ void PreloadGame()
     std::string legacySaveLocker = makeGameSavePath(w.WorldFilePath,
                                                     fmt::format_ne("save{0}.nosave", selSave));
 
+    Files::Data temp_save_data;
+
     if(Files::fileExists(savePath))
+    {
         XMessage::g_session.save_present = 2;
+
+        s_preloaded = true;
+        s_open_gamesave = Files::open_file(savePath, "r+");
+        temp_save_data = Files::load_file(s_open_gamesave);
+    }
     else if(!Files::fileExists(legacySaveLocker) && Files::fileExists(savePathOld))
+    {
         XMessage::g_session.save_present = 1;
+        temp_save_data = Files::load_file(savePathOld);
+    }
     else
     {
         pLogDebug("Game save file not found: %s", savePath.c_str());
         return;
     }
 
-    Files::Data temp_save_data = Files::load_file((XMessage::g_session.save_present == 2) ? savePath : savePathOld);
     XMessage::g_session.save_data.assign(temp_save_data.c_str(), temp_save_data.size());
+
 }
 #endif // #ifdef THEXTECH_ENABLE_SDL_NET
 
@@ -427,6 +464,8 @@ void LoadGame()
     else
         return;
 #else // #ifdef THEXTECH_ENABLE_SDL_NET
+    CloseSave();
+
     const auto &w = SelectWorld[selWorld];
 
     std::string savePath = makeGameSavePath(w.WorldFilePath,
@@ -436,7 +475,10 @@ void LoadGame()
                                                     fmt::format_ne("save{0}.nosave", selSave));
 
     if(Files::fileExists(savePath))
-        FileFormats::ReadExtendedSaveFileF(savePath, sav);
+    {
+        s_open_gamesave = Files::open_file(savePath, "r+");
+        FileFormats::ReadExtendedSaveFileF(s_open_gamesave, sav);
+    }
     else if(!Files::fileExists(legacySaveLocker) && Files::fileExists(savePathOld))
         FileFormats::ReadSMBX64SavFileF(savePathOld, sav);
     else
@@ -573,6 +615,12 @@ void LoadGame()
 
 void ClearGame(bool punnish)
 {
+    // allow a single call to ClearGame when preloaded
+    if(s_preloaded)
+        s_preloaded = false;
+    else
+        CloseSave();
+
     curWorldMusic = 0;
     curWorldMusicFile.clear();
 
@@ -717,4 +765,15 @@ void CopySave(int world, int src, int dst)
 #ifdef __EMSCRIPTEN__
     AppPathManager::syncFs();
 #endif
+}
+
+void CloseSave()
+{
+    s_preloaded = false;
+
+    if(s_open_gamesave)
+    {
+        SDL_RWclose(s_open_gamesave);
+        s_open_gamesave = nullptr;
+    }
 }

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -34,6 +34,7 @@
 #include <PGE_File_Formats/file_formats.h>
 #include <fmt_format_ne.h>
 #include <IniProcessor/ini_processing.h>
+#include <SDL2/SDL_rwops.h>
 #include <script/luna/lunacounter.h>
 #include <Logger/logger.h>
 
@@ -465,7 +466,8 @@ void LoadGame()
     if(Files::fileExists(savePath))
     {
         s_open_gamesave = Files::open_file(savePath, "r+");
-        FileFormats::ReadExtendedSaveFileF(s_open_gamesave, sav);
+        PGE_FileFormats_misc::RWopsTextInput inp = inp(s_open_gamesave);
+        FileFormats::ReadExtendedSaveFile(inp, sav);
     }
     else if(!Files::fileExists(legacySaveLocker) && Files::fileExists(savePathOld))
         FileFormats::ReadSMBX64SavFileF(savePathOld, sav);

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -254,22 +254,13 @@ void FindSaves()
                     info.ConfigDefaults = Config_t::MODE_CLASSIC + 1;
             }
 
+            // (these are just previews, so it's okay if we miss legacy files here)
+
             // load timer info for existing save
             info.Time = f.speedrunTicks;
 
             // load fails for existing save
-            std::string savePath = makeGameSavePath(w.WorldFilePath,
-                                        fmt::format_ne("fails-{0}.rip", A));
-
-            if(Files::fileExists(savePath))
-            {
-                gDeathCounter.counterFile = savePath;
-                gDeathCounter.TryLoadStats();
-                gDeathCounter.Recount();
-                info.FailsEnabled = true;
-                info.Fails = gDeathCounter.mCurTotalDeaths;
-                gDeathCounter.quit();
-            }
+            info.Fails = f.totalFails;
         }
     }
 }
@@ -318,6 +309,8 @@ void SaveGame()
     sav.speedrunTicks = g_speedrunTicks;
     sav.speedrunWinTicks = g_speedrunWinTicks;
     g_speedrunTicksSaved = g_speedrunTicks;
+
+    sav.totalFails = g_totalFails;
 
     for(A = 1; A <= 5; A++)
     {
@@ -504,6 +497,8 @@ void LoadGame()
     g_speedrunTicksSaved = sav.speedrunTicks;
     g_speedrunWinTicks = sav.speedrunWinTicks;
 
+    g_totalFails = sav.totalFails;
+
     if(Lives > 99)
         Lives = 99;
     if(Coins > 99)
@@ -610,6 +605,13 @@ void LoadGame()
 #endif
 
     ImportLevelSaveInfo(sav);
+
+    // import legacy fail counter data
+    if(g_totalFails == -1)
+    {
+        if(gDeathCounter.TryLoadStats())
+            SaveGame();
+    }
 }
 
 void ClearGame(bool punnish)
@@ -658,6 +660,7 @@ void ClearGame(bool punnish)
     Star.clear();
     numStars = 0;
 
+    g_totalFails = 0;
     LevelSaveEntries.clear();
 
     // Clear the speed-runner timer

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -466,7 +466,7 @@ void LoadGame()
     if(Files::fileExists(savePath))
     {
         s_open_gamesave = Files::open_file(savePath, "r+");
-        PGE_FileFormats_misc::RWopsTextInput inp = inp(s_open_gamesave);
+        PGE_FileFormats_misc::RWopsTextInput inp(s_open_gamesave);
         FileFormats::ReadExtendedSaveFile(inp, sav);
     }
     else if(!Files::fileExists(legacySaveLocker) && Files::fileExists(savePathOld))

--- a/src/main/game_save.cpp
+++ b/src/main/game_save.cpp
@@ -255,19 +255,10 @@ void FindSaves()
             }
 
             // load timer info for existing save
-            std::string savePath = makeGameSavePath(w.WorldFilePath,
-                                                     fmt::format_ne("timers{0}.ini", A));
-
-            if(Files::fileExists(savePath))
-            {
-                IniProcessing timer(savePath);
-                timer.beginGroup("timers");
-                timer.read("total", info.Time, 0);
-                timer.endGroup();
-            }
+            info.Time = f.speedrunTicks;
 
             // load fails for existing save
-            savePath = makeGameSavePath(w.WorldFilePath,
+            std::string savePath = makeGameSavePath(w.WorldFilePath,
                                         fmt::format_ne("fails-{0}.rip", A));
 
             if(Files::fileExists(savePath))
@@ -323,6 +314,10 @@ void SaveGame()
     sav.points = uint32_t(Score);
     sav.worldPosX = (int)WorldPlayer[1].Location.X;
     sav.worldPosY = (int)WorldPlayer[1].Location.Y;
+
+    sav.speedrunTicks = g_speedrunTicks;
+    sav.speedrunWinTicks = g_speedrunWinTicks;
+    g_speedrunTicksSaved = g_speedrunTicks;
 
     for(A = 1; A <= 5; A++)
     {
@@ -505,6 +500,10 @@ void LoadGame()
     WorldPlayer[1].Location.X = sav.worldPosX;
     WorldPlayer[1].Location.Y = sav.worldPosY;
 
+    g_speedrunTicks = sav.speedrunTicks;
+    g_speedrunTicksSaved = sav.speedrunTicks;
+    g_speedrunWinTicks = sav.speedrunWinTicks;
+
     if(Lives > 99)
         Lives = 99;
     if(Coins > 99)
@@ -660,6 +659,9 @@ void ClearGame(bool punnish)
     numStars = 0;
 
     LevelSaveEntries.clear();
+
+    // Clear the speed-runner timer
+    speedRun_resetTotal();
 
 #ifdef THEXTECH_ENABLE_LUNA_AUTOCODE
     gLunaVarBank = saveUserData::DataSection();

--- a/src/main/game_save.h
+++ b/src/main/game_save.h
@@ -24,6 +24,16 @@
 
 #include <string>
 
+struct SDL_RWops;
+
+struct GamesaveAccess final
+{
+    SDL_RWops* savefile;
+
+    GamesaveAccess();
+    ~GamesaveAccess();
+};
+
 void FindSaves();
 
 extern std::string makeGameSavePath(std::string episode, std::string saveFile);
@@ -38,5 +48,8 @@ void LoadGame();
 void ClearGame(bool punnish = false);
 void DeleteSave(int world, int save);
 void CopySave(int world, int src, int dst);
+
+// close any open game save
+void CloseSave();
 
 #endif // GAME_SAVE_H

--- a/src/main/gameplay_timer.cpp
+++ b/src/main/gameplay_timer.cpp
@@ -21,6 +21,7 @@
 
 #include <fmt_format_ne.h>
 #include <IniProcessor/ini_processing.h>
+#include <SDL2/SDL_rwops.h>
 
 #include "sdl_proxy/sdl_stdinc.h"
 
@@ -184,7 +185,7 @@ void GameplayTimer::save()
     if(save_access.savefile)
     {
         char buf[64];
-        int size = snprintf(buf, 64, "SAVE_HEADER\nSR:%ld;\nSAVE_HEADER_END\n", g_speedrunTicks);
+        int size = snprintf(buf, 64, "SAVE_HEADER\nSR:%ld;\nSAVE_HEADER_END\n", (long)g_speedrunTicks);
         if((int)SDL_RWwrite(save_access.savefile, buf, 1, size) != size)
             pLogCritical("Could not append speedrun timer to save file.");
     }

--- a/src/main/gameplay_timer.cpp
+++ b/src/main/gameplay_timer.cpp
@@ -113,12 +113,13 @@ GameplayTimer::GameplayTimer() = default;
 
 void GameplayTimer::reset()
 {
+    g_speedrunTicks = -1;
+    g_speedrunTicksSaved = -1;
+    g_speedrunWinTicks = 0;
+
     m_invalidContinue = false;
-    m_cyclesInt = false;
-    m_cyclesAtWin = 0;
     m_cyclesAtWinDisplay = 0;
     m_cyclesCurrent = 0;
-    m_cyclesTotal = 0;
     m_levelBlinkActive = false;
     m_worldBlinkActive = false;
     m_blinkingFactor = 0;
@@ -134,64 +135,72 @@ void GameplayTimer::resetCurrent()
 
 void GameplayTimer::load()
 {
+    if(g_speedrunTicks != -1)
+    {
+        // already loaded from gamesave
+        return;
+    }
+
     if(TestLevel || selSave == 0)
     {
         reset();
         return;
     }
 
+    // load legacy speedrun ini
     IniProcessing o;
     std::string savePath = makeGameSavePath(SelectWorld[selWorld].WorldFilePath,
                                             fmt::format_ne("timers{0}.ini", selSave));
     o.open(savePath);
 
     o.beginGroup("timers");
-    o.read("int", m_cyclesInt, false);
-    o.read("total", m_cyclesTotal, 0);
+    bool cyclesInt = false;
+    o.read("int", cyclesInt, false);
+    o.read("total", g_speedrunTicks, -1);
 
     // no longer permanently stop the timer following credits roll, but do store the cycles at first win for future display
     bool legacy_fin = false;
     o.read("fin", legacy_fin, false);
-    int64_t cyclesAtWin_default = (legacy_fin) ? m_cyclesTotal : 0;
+    int64_t cyclesAtWin_default = (legacy_fin) ? g_speedrunTicks : 0;
 
-    o.read("win", m_cyclesAtWin, cyclesAtWin_default);
+    o.read("win", g_speedrunWinTicks, cyclesAtWin_default);
     m_cyclesCurrent = 0; // Reset the counter
     m_cyclesAtWinDisplay = 0;
     o.endGroup();
 
-    if(!m_cyclesInt)
+    if(!cyclesInt)
         m_invalidContinue = true;
 }
 
 void GameplayTimer::save()
 {
     // should Cheater also be a condition here?
-    if(TestLevel || !selSave || m_invalidContinue)
+    if(TestLevel || !selSave || m_invalidContinue || g_speedrunTicks == g_speedrunTicksSaved)
         return;
 
-    IniProcessing o;
-    std::string savePath = makeGameSavePath(SelectWorld[selWorld].WorldFilePath,
-                                            fmt::format_ne("timers{0}.ini", selSave));
-    o.open(savePath);
+    g_speedrunTicksSaved = g_speedrunTicks;
 
-    o.beginGroup("timers");
-    o.setValue("int", m_cyclesInt);
-    o.setValue("total", m_cyclesTotal);
-    o.setValue("win", m_cyclesAtWin);
-    o.endGroup();
+    GamesaveAccess save_access;
+    if(save_access.savefile)
+    {
+        char buf[64];
+        int size = snprintf(buf, 64, "SAVE_HEADER\nSR:%ld;\nSAVE_HEADER_END\n", g_speedrunTicks);
+        if((int)SDL_RWwrite(save_access.savefile, buf, 1, size) != size)
+            pLogCritical("Could not append speedrun timer to save file.");
+    }
 
-    o.writeIniFile();
+    // Maybe also delete legacy speedrun ini? Not sure...
 }
 
 void GameplayTimer::tick()
 {
     // initialize timer
-    if(!m_cyclesInt)
+    if(g_speedrunTicks == -1)
     {
-        m_cyclesInt = true;
+        g_speedrunTicks = 0;
+        g_speedrunWinTicks = 0;
+
         m_cyclesCurrent = 0;
-        m_cyclesTotal = 0;
-        m_cyclesAtWin = 0;
         m_cyclesAtWinDisplay = 0;
         m_levelBlinkActive = false;
         m_worldBlinkActive = false;
@@ -206,7 +215,7 @@ void GameplayTimer::tick()
     else if(!in_leveltest_restart_screen && g_config.show_playtime_counter == Config_t::PLAYTIME_COUNTER_ANIMATED)
         m_levelBlinkActive = true;
 
-    m_cyclesTotal += 1;
+    g_speedrunTicks += 1;
 
     if(m_levelBlinkActive)
         updateColorSpin(5);
@@ -221,10 +230,10 @@ void GameplayTimer::tick()
 
 void GameplayTimer::onBossDead()
 {
-    m_cyclesAtWinDisplay = m_cyclesTotal;
+    m_cyclesAtWinDisplay = g_speedrunTicks;
 
-    if(m_cyclesAtWin == 0)
-        m_cyclesAtWin = m_cyclesTotal;
+    if(g_speedrunWinTicks == 0)
+        g_speedrunWinTicks = g_speedrunTicks;
 
     if(g_config.show_playtime_counter == Config_t::PLAYTIME_COUNTER_ANIMATED)
         m_worldBlinkActive = true;
@@ -245,7 +254,7 @@ void GameplayTimer::render()
         SuperPrintScreenCenter(g_mainMenu.caseNone,         3, y - 18, XTColor(127, 127, 127, a));
     else if(!TestLevel)
     {
-        int64_t use_total = m_cyclesTotal;
+        int64_t use_total = g_speedrunTicks;
         if(m_cyclesAtWinDisplay)
             use_total = m_cyclesAtWinDisplay;
 

--- a/src/main/gameplay_timer.h
+++ b/src/main/gameplay_timer.h
@@ -29,12 +29,9 @@
 class GameplayTimer
 {
     bool    m_invalidContinue = false;
-    bool    m_cyclesInt = false;
     // bool    m_cyclesFin = false;
-    int64_t m_cyclesAtWin = 0;
     int64_t m_cyclesAtWinDisplay = 0;
     int64_t m_cyclesCurrent = 0;
-    int64_t m_cyclesTotal = 0;
 
     bool    m_levelBlinkActive = false;
     bool    m_worldBlinkActive = false;

--- a/src/main/level_save_info.cpp
+++ b/src/main/level_save_info.cpp
@@ -56,6 +56,8 @@ static bool s_exportSingleSaveInfo(saveLevelInfo& s, const LevelSaveInfo_t& info
         s.medals_best[i] = (info.medals_best & (1 << i));
     }
 
+    s.fails = info.fails;
+
     return true;
 }
 
@@ -93,6 +95,8 @@ static bool s_importSingleSaveInfo(LevelSaveInfo_t& info, const saveLevelInfo& s
             info.medals_best |= (1 << i);
     }
 
+    info.fails = s.fails;
+
     return true;
 }
 
@@ -121,6 +125,9 @@ void ImportLevelSaveInfo(const GamesaveData& s)
             if(ent.levelPath == e.level_filename)
             {
                 is_duplicate = true;
+                // update fails counter
+                if(e.fails > ent.save_info.fails)
+                    ent.save_info.fails = e.fails;
                 break;
             }
         }

--- a/src/main/menu_main.cpp
+++ b/src/main/menu_main.cpp
@@ -2071,7 +2071,7 @@ static void s_drawGameSaves(int MenuX, int MenuY)
         int row_2 = infobox_y + 42;
         int row_c = infobox_y + 26;
 
-        bool hasFails = (g_config.enable_fails_tracking || info.FailsEnabled);
+        bool hasFails = (info.Fails != -1);
         bool show_timer = info.Time > 0 && (g_config.enable_playtime_tracking || info.ConfigDefaults < 0);
         bool show_score = (s_episode_playstyle != Config_t::MODE_VANILLA);
 

--- a/src/main/speedrunner.cpp
+++ b/src/main/speedrunner.cpp
@@ -34,11 +34,12 @@
 
 static      GameplayTimer s_gamePlayTimer;
 
+int64_t g_speedrunTicks = -1;
+int64_t g_speedrunTicksSaved = -1;
+int64_t g_speedrunWinTicks = 0;
+
 void speedRun_loadStats()
 {
-    if(!g_config.enable_playtime_tracking)
-        return; // Do nothing
-
     s_gamePlayTimer.load();
 }
 
@@ -55,17 +56,11 @@ void speedRun_saveStats()
 
 void speedRun_resetCurrent()
 {
-    if(!g_config.enable_playtime_tracking)
-        return; // Do nothing
-
     s_gamePlayTimer.resetCurrent();
 }
 
 void speedRun_resetTotal()
 {
-    if(!g_config.enable_playtime_tracking)
-        return; // Do nothing
-
     s_gamePlayTimer.reset();
 }
 

--- a/src/main/speedrunner.h
+++ b/src/main/speedrunner.h
@@ -24,6 +24,10 @@
 
 #include "control_types.h"
 
+extern int64_t g_speedrunTicks;
+extern int64_t g_speedrunTicksSaved;
+extern int64_t g_speedrunWinTicks;
+
 namespace XPower { struct StatusInfo; }
 
 enum

--- a/src/script/luna/lunacounter.cpp
+++ b/src/script/luna/lunacounter.cpp
@@ -37,16 +37,54 @@
 #include "main/game_save.h"
 #include "main/game_info.h"
 #include "main/menu_main.h"
+#include "main/level_save_info.h"
+
+static char* s_escaped_strcpy(char* dest, char* end, const std::string& src)
+{
+    for(char c : src)
+    {
+        if(dest == end - 1 || dest == end)
+            return nullptr;
+
+        switch(c)
+        {
+        case '\n':
+            *(dest++) = '\\';
+            *(dest++) = 'n';
+            break;
+        case '\r':
+            *(dest++) = '\\';
+            *(dest++) = 'r';
+            break;
+        case '\"':
+        case ';':
+        case ':':
+        case '[':
+        case ']':
+        case ',':
+        case '%':
+        case '\\':
+            *(dest++) = '\\';
+            *(dest++) = c;
+            break;
+        default:
+            *(dest++) = c;
+            break;
+        }
+    }
+
+    return dest;
+}
 
 
+int g_totalFails = 0;
 DeathCounter gDeathCounter;
 
 // CTOR
 DeathCounter::DeathCounter() noexcept
 {
-    mStatFileOK = false;
     mEnabled = false;
-    mCurTotalDeaths = 0;
+    g_totalFails = 0;
     mCurLevelDeaths = 0;
 
     // Print Demos counter with a font 3
@@ -55,138 +93,74 @@ DeathCounter::DeathCounter() noexcept
 
 DeathCounter::~DeathCounter() noexcept
 {
-    if(m_openFile)
-        SDL_RWclose(m_openFile);
 }
 
 void DeathCounter::init()
 {
-    if(counterFile.empty())
-    {
-        // prevent a segfault
-        if(TestLevel || selWorld < 0 || selWorld >= (int)SelectWorld.size() || BattleMode || LevelEditor || selSave <= 0)
-        {
-            mEnabled = false;
-            return;
-        }
-
-        std::string oldFile = makeGameSavePath(SelectWorld[selWorld].WorldFilePath,
-                                               fmt::format_ne("demos-{0}.dmo", selSave));
-
-        std::string oldFile2 = makeGameSavePath(SelectWorld[selWorld].WorldFilePath,
-                                               fmt::format_ne("deaths-{0}.rip", selSave));
-
-        counterFile = makeGameSavePath(SelectWorld[selWorld].WorldFilePath,
-                                       fmt::format_ne("fails-{0}.rip", selSave));
-
-        if(Files::fileExists(oldFile)) // Rename old file ino the new name
-            Files::moveFile(counterFile, oldFile);
-        else if(Files::fileExists(oldFile2)) // Rename old file ino the new name
-            Files::moveFile(counterFile, oldFile2);
-
-        if(!TryLoadStats())
-            mEnabled = false;
-    }
+    mEnabled = (g_totalFails != -1);
 }
 
 void DeathCounter::quit()
 {
-    counterFile.clear();
-    mStatFileOK = false;
     mEnabled = false;
-    mCurTotalDeaths = 0;
     mCurLevelDeaths = 0;
-    mDeathRecords.clear();
-
-    if(m_openFile)
-    {
-        SDL_RWclose(m_openFile);
-        m_openFile = nullptr;
-    }
 }
 
-// TRY LOAD STATS - Attempts to load stats from stats file. Creates and inits the file if it doesn't exist.
+// TRY LOAD STATS - Attempts to load stats from legacy stats file.
 bool DeathCounter::TryLoadStats()
 {
+    if(g_totalFails != -1)
+        return true;
+
+    // prevent a segfault
+    if(TestLevel || selWorld < 0 || selWorld >= (int)SelectWorld.size() || BattleMode || LevelEditor || selSave <= 0)
+        return false;
+
+    std::string oldFile = makeGameSavePath(SelectWorld[selWorld].WorldFilePath,
+                                           fmt::format_ne("demos-{0}.dmo", selSave));
+
+    std::string oldFile2 = makeGameSavePath(SelectWorld[selWorld].WorldFilePath,
+                                           fmt::format_ne("deaths-{0}.rip", selSave));
+
+    std::string counterFile = makeGameSavePath(SelectWorld[selWorld].WorldFilePath,
+                                   fmt::format_ne("fails-{0}.rip", selSave));
+
+    if(Files::fileExists(oldFile)) // Rename old file ino the new name
+        Files::moveFile(counterFile, oldFile);
+    else if(Files::fileExists(oldFile2)) // Rename old file ino the new name
+        Files::moveFile(counterFile, oldFile2);
+
     // Try to open the file
     int32_t tempint = 0;
     size_t got;
 
-    // If file is not exist yet, try to create empty file
-    if(!Files::fileExists(counterFile))
-    {
-        SDL_RWops *statsfile = Files::open_file(counterFile, "wb");
-        if(!statsfile)
-        {
-            mStatFileOK = false;
-            mEnabled = false;
-            pLogWarning("Unable to initialize Demos counter: %s", counterFile.c_str());
-            return false;
-        }
-
-        SDL_RWwrite(statsfile, &tempint, 1, sizeof(int));
-        SDL_RWclose(statsfile);
-    }
-
-    // close old open file if present
-    if(m_openFile)
-    {
-        SDL_RWclose(m_openFile);
-        m_openFile = nullptr;
-    }
-
-    m_openFile = Files::open_file(counterFile, "r+b");
+    SDL_RWops* openFile = Files::open_file(counterFile, "rb");
 
     // If create failed, disable death counter
-    if(!m_openFile)
+    if(!openFile)
     {
-        pLogWarning("Unable to open the Demos counter: %s", counterFile.c_str());
-        mStatFileOK = false;
-        mEnabled = false;
+        pLogWarning("Unable to restore from the legacy Demos counter: %s", counterFile.c_str());
         return false;
     }
 
-    // If size less than 100, init new file
-    int cursize = (int)SDL_RWsize(m_openFile);
-
-    if(cursize < 50)
-    {
-        InitStatsFile(m_openFile);
-        Files::flush_file(m_openFile);
-        mStatFileOK = true;
-        SDL_RWseek(m_openFile, 0, SEEK_SET);
-    }
-
-//    if(statsfile.good() == false)
-//    {
-//        mStatFileOK = false;
-//        mEnabled = false;
-//        return false;
-//    }
-
     // Check version
-    got = LunaCounterUtil::readIntLE(m_openFile, tempint);
+    got = LunaCounterUtil::readIntLE(openFile, tempint);
     if(got != sizeof(int32_t) || tempint < 5)
     {
         if(got != sizeof(int32_t))
             pLogWarning("Fails counter: Failed to read version number at the %s file", counterFile.c_str());
 
-        mStatFileOK = false;
         mEnabled = false;
 
-        SDL_RWclose(m_openFile);
-        m_openFile = nullptr;
+        SDL_RWclose(openFile);
+        openFile = nullptr;
 
         return false;
     }
 
-    mStatFileOK = true;
-    mEnabled = true;
+    ReadRecords(openFile);
 
-    ClearRecords();
-    ReadRecords(m_openFile);
-
-    return true;
+    return (g_totalFails != -1);
 }
 
 // mark that a death occurred in the current level
@@ -197,65 +171,44 @@ void DeathCounter::MarkDeath(bool write_save)
     if(!dcAllow)
         return;
 
-    AddDeath(FileNameFull, 1);
+    LevelSaveInfo_t* info = CurSaveInfo();
+
+    if(info)
+        info->fails++;
+
+    g_totalFails++;
+    mCurLevelDeaths++;
 
     if(write_save)
     {
-        TrySave();
-        Recount();
-    }
-}
-
-// ADD DEATH
-void DeathCounter::AddDeath(const std::string &lvlname, int amount)
-{
-    if(!mEnabled)
-        return;
-
-    for(auto &iter : mDeathRecords)
-    {
-        if(iter.m_levelName == lvlname)   // On first name match...
+        GamesaveAccess save_access;
+        if(save_access.savefile)
         {
-            iter.m_deaths += amount;      // Inc death count
-            return;                        // and exit
+            bool failed = false;
+            std::array<char, 384> buf;
+
+            // update total fail count
+            int size = snprintf(buf.data(), 384, "SAVE_HEADER\nTF:%d;\nSAVE_HEADER_END\n", g_totalFails);
+            if((int)SDL_RWwrite(save_access.savefile, buf.data(), 1, size) != size)
+                failed = true;
+
+            if(!failed && info)
+            {
+                strcpy(buf.data(), "LEVEL_INFO\nL:\"");
+                char* dest = buf.data() + 14;
+                dest = s_escaped_strcpy(dest, buf.end(), FileNameFull);
+                if(dest)
+                    dest += snprintf(dest, buf.end() - dest, "\";F:%d;\nLEVEL_INFO_END\n", info->fails);
+                size = dest - buf.data();
+            }
+
+            if(failed || (int)SDL_RWwrite(save_access.savefile, buf.data(), 1, size) != size)
+                pLogCritical("Could not append fail to save file.");
         }
     }
-
-    // if no match, create new death record and add it to list
-    DeathRecord newrec;
-    newrec.m_levelName = lvlname;
-    newrec.m_deaths = amount;
-    mDeathRecords.push_back(newrec);
 }
 
-// INIT STATS FILE
-void DeathCounter::InitStatsFile(SDL_RWops *statsfile)
-{
-    WriteHeader(statsfile);
-}
-
-
-// WRITE HEADER - Write the death counter file header at beginning of file
-void DeathCounter::WriteHeader(SDL_RWops *statsfile)
-{
-    // Write dll version
-    SDL_RWseek(statsfile, 0, RW_SEEK_SET);
-    LunaCounterUtil::writeIntLE(statsfile, LUNA_VERSION);
-
-    // Init reserved
-    uint8_t writebyte = 0;
-    off_t offset = SDL_RWtell(statsfile);
-    while(offset < 100)
-    {
-        SDL_RWwrite(statsfile, &writebyte, 1, sizeof(writebyte));
-        offset = SDL_RWtell(statsfile);
-    }
-
-    // Write record count at 100 bytes (0 record count)
-    LunaCounterUtil::writeIntLE(statsfile, 0);
-}
-
-// READ RECORDS - Add death records from file into death record list
+// READ RECORDS - Add death records from legacy file into death record list
 void DeathCounter::ReadRecords(SDL_RWops *statsfile)
 {
     int32_t tempint = 0;
@@ -274,85 +227,50 @@ void DeathCounter::ReadRecords(SDL_RWops *statsfile)
     if(tempint == 0)
         return;
 
+    g_totalFails = 0;
+
+    DeathRecord newrec;
     for(int i = 0; i < tempint; i++)
     {
-        DeathRecord newrec;
         if(newrec.Load(statsfile))
-            mDeathRecords.push_back(newrec);
-    }
-}
-
-
-// WRITE RECORDS - Writes death record count at pos 100 in the file followed by each record
-void DeathCounter::WriteRecords(SDL_RWops *statsfile)
-{
-    int32_t reccount = (int32_t)mDeathRecords.size();
-    SDL_RWseek(statsfile, 100, RW_SEEK_SET);
-    LunaCounterUtil::writeIntLE(statsfile, reccount);
-
-    // Write each record, if any exist
-    if(!mDeathRecords.empty())
-    {
-        for(auto &mDeathRecord : mDeathRecords)
-            mDeathRecord.Save(statsfile);
-    }
-}
-
-// TRY SAVE - Externally callable, safe auto-save function
-void DeathCounter::TrySave()
-{
-    if(mStatFileOK && mEnabled && m_openFile)
-    {
-        if(SDL_RWseek(m_openFile, 0, RW_SEEK_SET))
         {
-            // attempt to reopen the file
-            SDL_RWclose(m_openFile);
-            m_openFile = Files::open_file(counterFile, "wb");
-        }
+            g_totalFails += newrec.m_deaths;
 
-        if(m_openFile)
-        {
-            Save(m_openFile);
-            Files::flush_file(m_openFile);
+            for(auto& e : LevelSaveEntries)
+            {
+                if(e.levelPath == newrec.m_levelName)
+                    e.save_info.fails = newrec.m_deaths;
+            }
         }
     }
 }
 
-// SAVE
-void DeathCounter::Save(SDL_RWops *statsfile)
-{
-    if(mStatFileOK && mEnabled)
-    {
-        WriteHeader(statsfile);
-        WriteRecords(statsfile);
-    }
-}
 
-
-// CLEAR RECORDS - Clear the death record list and dealloc its records
+// CLEAR RECORDS - Reset the death records for every level
 void DeathCounter::ClearRecords()
 {
-    mDeathRecords.clear();
+    g_totalFails = 0;
+    for(auto& e : LevelSaveEntries)
+        e.save_info.fails = 0;
+
+    mCurLevelDeaths = 0;
+
+    // must save game to prevent conflicts with updates
+    SaveGame();
 }
 
-// RECOUNT - Recount and relist the death count for the current level and the total deathcount
+// RECOUNT - Recount and relist the death count for the current level
 void DeathCounter::Recount()
 {
     if(!mEnabled)
         return;
 
-    int total = 0;
-    mCurLevelDeaths = 0;
+    LevelSaveInfo_t* info = CurSaveInfo();
 
-    for(const auto &iter : mDeathRecords)
-    {
-        total += iter.m_deaths;
-        if(iter.m_levelName == FileNameFull)
-            mCurLevelDeaths = iter.m_deaths;
-    }
-
-    mCurTotalDeaths = total;
-
+    if(info)
+        mCurLevelDeaths = info->fails;
+    else
+        mCurLevelDeaths = 0;
 }
 
 // DRAW - Print the death counter in its current state
@@ -362,7 +280,7 @@ void DeathCounter::Draw(int screenZ)
         return;
 
     // Format string to print
-    m_print.syncCache(mCurLevelDeaths, mCurTotalDeaths);
+    m_print.syncCache(mCurLevelDeaths, g_totalFails);
     m_print.syncCache(g_gameInfo.fails_counter_title);
 
     const vScreen_t& vscreen = vScreen[screenZ];

--- a/src/script/luna/lunacounter.cpp
+++ b/src/script/luna/lunacounter.cpp
@@ -189,20 +189,21 @@ void DeathCounter::MarkDeath(bool write_save)
 
             // update total fail count
             int size = snprintf(buf.data(), 384, "SAVE_HEADER\nTF:%d;\nSAVE_HEADER_END\n", g_totalFails);
-            if((int)SDL_RWwrite(save_access.savefile, buf.data(), 1, size) != size)
+            if((int)SDL_RWwrite(save_access.savefile, &buf[0], 1, size) != size)
                 failed = true;
 
             if(!failed && info)
             {
                 strcpy(buf.data(), "LEVEL_INFO\nL:\"");
-                char* dest = buf.data() + 14;
-                dest = s_escaped_strcpy(dest, buf.end(), FileNameFull);
+                char* dest = &buf[14];
+                char* buf_end = &buf[0] + buf.size();
+                dest = s_escaped_strcpy(dest, buf_end, FileNameFull);
                 if(dest)
-                    dest += snprintf(dest, buf.end() - dest, "\";F:%d;\nLEVEL_INFO_END\n", info->fails);
-                size = dest - buf.data();
+                    dest += snprintf(dest, buf_end - dest, "\";F:%d;\nLEVEL_INFO_END\n", info->fails);
+                size = dest - &buf[0];
             }
 
-            if(failed || (int)SDL_RWwrite(save_access.savefile, buf.data(), 1, size) != size)
+            if(failed || (int)SDL_RWwrite(save_access.savefile, &buf[0], 1, size) != size)
                 pLogCritical("Could not append fail to save file.");
         }
     }

--- a/src/script/luna/lunacounter.h
+++ b/src/script/luna/lunacounter.h
@@ -31,6 +31,8 @@
 
 struct SDL_RWops;
 
+extern int g_totalFails;
+
 struct DeathCounter
 {
     DeathCounter() noexcept;
@@ -43,7 +45,6 @@ struct DeathCounter
     // Marks a death on the current level
     void MarkDeath(bool write_save = true);
     void AddDeath(const std::string &, int amount);
-    void TrySave();
     void Draw(int screenZ);
     void Recount();
     void ClearRecords();
@@ -66,26 +67,13 @@ struct DeathCounter
     } m_print;
 
 private:
-    SDL_RWops* m_openFile = nullptr;
-
     friend struct DeathRecord;
-    static void InitStatsFile(SDL_RWops *openfile);
-    static void WriteHeader(SDL_RWops *openfile);
-    void WriteRecords(SDL_RWops *statsfile);
     void ReadRecords(SDL_RWops *openfile);
-    void Save(SDL_RWops *openfile);
 
     // Members
 public:
-    bool mStatFileOK = false;
     bool mEnabled = false;
-
-    int mCurTotalDeaths = 0;
     int mCurLevelDeaths = 0;
-
-    std::list<DeathRecord> mDeathRecords;
-
-    std::string counterFile;
 };
 
 extern DeathCounter	gDeathCounter;

--- a/src/script/luna/lunacounter_record.cpp
+++ b/src/script/luna/lunacounter_record.cpp
@@ -25,21 +25,6 @@
 #include "sdl_proxy/sdl_stdinc.h"
 
 
-void DeathRecord::Save(SDL_RWops *openfile)
-{
-    // Write character count
-    auto tempint = (uint32_t)m_levelName.size();
-    LunaCounterUtil::writeUIntLE(openfile, tempint);
-
-    // Write string data
-    int16_t nullt = 0;
-    SDL_RWwrite(openfile, m_levelName.data(), 1, tempint);
-    SDL_RWwrite(openfile, &nullt, 1, sizeof(int16_t));
-
-    // Write death count
-    LunaCounterUtil::writeIntLE(openfile, m_deaths);
-}
-
 bool DeathRecord::Load(SDL_RWops *openfile)
 {
     size_t got;
@@ -74,7 +59,7 @@ bool DeathRecord::Load(SDL_RWops *openfile)
     if(skip > 0)
         SDL_RWseek(openfile, skip, RW_SEEK_CUR);
 
-    m_levelName = std::string(buf);
+    m_levelName = buf;
     SDL_RWseek(openfile, 2, RW_SEEK_CUR);
 
     // Read death count

--- a/src/script/luna/lunacounter_record.h
+++ b/src/script/luna/lunacounter_record.h
@@ -29,7 +29,6 @@
 
 struct DeathRecord
 {
-    void Save(SDL_RWops *openfile);
     bool Load(SDL_RWops *openfile);
 
     std::string m_levelName;

--- a/src/script/luna/lunainput.cpp
+++ b/src/script/luna/lunainput.cpp
@@ -228,8 +228,6 @@ void Input::CheckSpecialCheats()
         else if(cheats_contains(DELETE_ALL_RECORDS_CHT))
         {
             gDeathCounter.ClearRecords();
-            gDeathCounter.TrySave();
-            gDeathCounter.Recount();
             PlaySound(SFX_Smash);
             cheats_clearBuffer();
             return;


### PR DESCRIPTION
WARNING:
(1) This PR affects saving. Please be cautious and backup any saves before trying it.
(2) This PR introduces a new way of tracking gameplay time and fails. Post-PR TheXTech can read timer/fail records from pre-PR TheXTech, but pre-PR TheXTech cannot read records from post-PR TheXTech. This means that your timer/fail data will be lost if you resume a post-PR gamesave on a release build.

@Wohlstand, we should probably cherry-pick this to stable as well, and then merge this to all branches immediately before the next stable release.

PR features:
* Gamesaves now use a single SAVX file, without additional timer and fails files.
* The SAVX file is updated (without a full save) any time that the timer or fails files would have been updated, by appending new entries to the SAVX file.
* This speeds up the save/load processes, and makes it easier to track and transfer saves.